### PR TITLE
Correct bug on getVolumes() for windows

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -67,15 +67,11 @@ getVolumes <- function(exclude) {
             names(media) <- basename(media)
             volumes <- c(volumes, media)
         } else if (osSystem == 'Windows') {
-            volumes <- system('wmic logicaldisk get Caption', intern=T)
-            volumes <- sub(' *\\r$', '', volumes)
-            keep <- !tolower(volumes) %in% c('caption', '')
+            volumes <- system("wmic logicaldisk get name", intern = T)
+            volumes <- sub(" *\\r$", "", volumes)
+            keep <- !tolower(volumes) %in% c("name", "")
             volumes <- volumes[keep]
-            volNames <- system('wmic logicaldisk get VolumeName', intern=T)
-            volNames <- sub(' *\\r$', '', volNames)
-            volNames <- volNames[keep]
-            volNames <- paste0(volNames, ' (', volumes, ')')
-            names(volumes) <- volNames
+            names(volumes) <- volumes
         } else {
             stop('unsupported OS')
         }

--- a/inst/example/server.R
+++ b/inst/example/server.R
@@ -2,7 +2,7 @@ library(shiny)
 library(shinyFiles)
 
 shinyServer(function(input, output, session) {
-    volumes <- c('R Installation'=R.home())
+    volumes <- getVolumes() # c('R Installation'=R.home())
     shinyFileChoose(input, 'file', roots=volumes, session=session, restrictions=system.file(package='base'))
     shinyDirChoose(input, 'directory', roots=volumes, session=session, restrictions=system.file(package='base'))
     shinyFileSave(input, 'save', roots=volumes, session=session, restrictions=system.file(package='base'))


### PR DESCRIPTION
PR for issue #40 shinyDirChoose() with getVolumes() only select C:/ in windows 7
https://github.com/thomasp85/shinyFiles/issues/40