### PR TITLE
Fix crash on `parseSavePath` when UI does not have filetype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: r
-sudo: required
-bioc_required: true
-r_check_args: '--as-cran'
+cache: packages
+sudo: false
+
 r_github_packages:
   - jimhester/covr
+
 after_success:
-  - Rscript -e 'library(covr);codecov()'
+  - Rscript -e 'covr::codecov()'
+
+addons:
+  apt:
+    packages:
+      - libicu-dev
+

--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -408,9 +408,11 @@ shinyFilesButton <- function(id, label, title, multiple, buttonType='default', c
 parseFilePaths <- function(roots, selection) {
     roots <- if(class(roots) == 'function') roots() else roots
     
-    if (is.null(selection) || is.na(selection)) return(data.frame(name=character(0), size=numeric(0), type=character(0), datapath=character(0)))
+    if (is.null(selection) || is.na(selection)) return(data.frame(name=character(0), size=numeric(0),
+                                                                  type=character(0), datapath=character(0),
+                                                                  stringsAsFactors = FALSE))
     files <- sapply(selection$files, function(x) {file.path(roots[selection$root], do.call('file.path', x))})
     files <- gsub(pattern='//*', '/', files, perl=TRUE)
     
-    data.frame(name=basename(files), size=file.info(files)$size, type='', datapath=files)
+    data.frame(name=basename(files), size=file.info(files)$size, type='', datapath=files, stringsAsFactors = FALSE)
 }

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -113,7 +113,8 @@ formatFiletype <- function(filetype) {
 #' @export
 #' 
 parseSavePath <- function(roots, selection) {
-    if(is.null(selection)) return(data.frame(name=character(), type=character(), datapath=character()))
+    if(is.null(selection)) return(data.frame(name=character(), type=character(),
+                                             datapath=character(), stringsAsFactors = FALSE))
     
     currentRoots <- if(class(roots) == 'function') roots() else roots
     
@@ -124,6 +125,9 @@ parseSavePath <- function(roots, selection) {
     location <- do.call('file.path', as.list(selection$path))
     savefile <- file.path(root, location, selection$name)
     savefile <- gsub(pattern='//*', '/', savefile, perl=TRUE)
-    
-    data.frame(name=selection$name, type=selection$type, datapath=savefile)
+    type <- selection$type
+    if (is.null(type)) {
+        type <- ""
+    }
+    data.frame(name=selection$name, type=type, datapath=savefile, stringsAsFactors = FALSE)
 }


### PR DESCRIPTION
This PR closes #45.

I have not created a test but simply by removing the `filetype=list(text='txt', picture=c('jpeg', 'jpg'))` argument from the `inst/example/ui.R` file, running the app and trying to use the save file button can reproduce the error, and it is fixed after applying this patch.

Thanks for your time with this package!
