### PR TITLE
Let the user provide default paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: r
-sudo: required
-bioc_required: true
-r_check_args: '--as-cran'
+cache: packages
+sudo: false
+
 r_github_packages:
   - jimhester/covr
+
 after_success:
-  - Rscript -e 'library(covr);codecov()'
+  - Rscript -e 'covr::codecov()'
+
+addons:
+  apt:
+    packages:
+      - libicu-dev
+

--- a/R/dirchoose.R
+++ b/R/dirchoose.R
@@ -118,7 +118,7 @@ dirGetter <- function(roots, restrictions, filetypes, hidden=FALSE) {
         currentRoots <- if(class(roots) == 'function') roots() else roots
         
         if (is.null(names(currentRoots))) stop('Roots must be a named vector or a function returning one')
-        if (missing(root)) root <- names(currentRoots)[1]
+        if (is.null(root)) root <- names(currentRoots)[1]
         
         tree <- traverseDirs(tree, currentRoots[root], restrictions, hidden)
         
@@ -181,7 +181,8 @@ dirCreator <- function(roots, ...) {
 #' 
 #' @importFrom shiny observe invalidateLater
 #' 
-shinyDirChoose <- function(input, id, updateFreq=2000, session=getSession(), ...) {
+shinyDirChoose <- function(input, id, updateFreq=2000, session=getSession(),
+                           defaultPath='', defaultRoot=NULL, ...) {
     dirGet <- do.call('dirGetter', list(...))
     fileGet <- do.call('fileGetter', list(...))
     dirCreate <- do.call('dirCreator', list(...))
@@ -197,7 +198,7 @@ shinyDirChoose <- function(input, id, updateFreq=2000, session=getSession(), ...
             lastDirCreate <<- createDir
         }
         if(is.null(tree) || is.na(tree)) {
-            dir <- list(tree=list(name='', expanded=TRUE))
+            dir <- list(tree=list(name=defaultPath, expanded=TRUE), root=defaultRoot)
             files <- list(dir=NA, root=tree$selectedRoot)
         } else {
             dir <- list(tree=tree$tree, root=tree$selectedRoot)

--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -38,7 +38,7 @@ fileGetter <- function(roots, restrictions, filetypes, hidden=FALSE) {
         currentRoots <- if(class(roots) == 'function') roots() else roots
         
         if (is.null(names(currentRoots))) stop('Roots must be a named vector or a function returning one')
-        if (missing(root)) root <- names(currentRoots)[1]
+        if (is.null(root)) root <- names(currentRoots)[1]
         
         fulldir <- file.path(currentRoots[root], dir)
         writable <- as.logical(file.access(fulldir, 2) == 0)
@@ -112,6 +112,12 @@ fileGetter <- function(roots, restrictions, filetypes, hidden=FALSE) {
 #' @param session The session object of the shinyServer call (usually 
 #' \code{session}).
 #' 
+#' @param defaultRoot The default root to use. For instance if 
+#'                    \code{roots = c('wd' = '.', 'home', '/home')} then \code{defaultRoot} 
+#'                    can be either \code{'wd'} or \code{'home'}.
+#' 
+#' @param defaultPath The default relative path specified given the \code{defaultRoot}.
+#' 
 #' @param ... Arguments to be passed on to \code{\link{fileGetter}} or 
 #' \code{\link{dirGetter}}
 #' 
@@ -132,7 +138,8 @@ fileGetter <- function(roots, restrictions, filetypes, hidden=FALSE) {
 #'     shinyFilesButton('files', 'File select', 'Please select a file', FALSE)
 #' ))
 #' server <- shinyServer(function(input, output) {
-#'     shinyFileChoose(input, 'files', roots=c(wd='.'), filetypes=c('', 'txt'))
+#'     shinyFileChoose(input, 'files', roots=c(wd='.'), filetypes=c('', 'txt'),
+#'                     defaultPath='', defaultRoot='wd')
 #' })
 #' 
 #' runApp(list(
@@ -150,14 +157,15 @@ fileGetter <- function(roots, restrictions, filetypes, hidden=FALSE) {
 #' 
 #' @export
 #' 
-shinyFileChoose <- function(input, id, updateFreq=2000, session = getSession(), ...) {
+shinyFileChoose <- function(input, id, updateFreq=2000, session = getSession(), 
+                            defaultRoot=NULL, defaultPath='', ...) {
     fileGet <- do.call('fileGetter', list(...))
     currentDir <- list()
     
     return(observe({
         dir <- input[[paste0(id, '-modal')]]
         if(is.null(dir) || is.na(dir)) {
-            dir <- list(dir='')
+            dir <- list(dir=defaultPath, root=defaultRoot)
         } else {
             dir <- list(dir=dir$path, root=dir$root)
         }

--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -408,9 +408,11 @@ shinyFilesButton <- function(id, label, title, multiple, buttonType='default', c
 parseFilePaths <- function(roots, selection) {
     roots <- if(class(roots) == 'function') roots() else roots
     
-    if (is.null(selection) || is.na(selection)) return(data.frame(name=character(0), size=numeric(0), type=character(0), datapath=character(0)))
+    if (is.null(selection) || is.na(selection)) return(data.frame(name=character(0), size=numeric(0),
+                                                                  type=character(0), datapath=character(0),
+                                                                  stringsAsFactors = FALSE))
     files <- sapply(selection$files, function(x) {file.path(roots[selection$root], do.call('file.path', x))})
     files <- gsub(pattern='//*', '/', files, perl=TRUE)
     
-    data.frame(name=basename(files), size=file.info(files)$size, type='', datapath=files)
+    data.frame(name=basename(files), size=file.info(files)$size, type='', datapath=files, stringsAsFactors = FALSE)
 }

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -113,7 +113,8 @@ formatFiletype <- function(filetype) {
 #' @export
 #' 
 parseSavePath <- function(roots, selection) {
-    if(is.null(selection)) return(data.frame(name=character(), type=character(), datapath=character()))
+    if(is.null(selection)) return(data.frame(name=character(), type=character(),
+                                             datapath=character(), stringsAsFactors = FALSE))
     
     currentRoots <- if(class(roots) == 'function') roots() else roots
     
@@ -124,6 +125,9 @@ parseSavePath <- function(roots, selection) {
     location <- do.call('file.path', as.list(selection$path))
     savefile <- file.path(root, location, selection$name)
     savefile <- gsub(pattern='//*', '/', savefile, perl=TRUE)
-    
-    data.frame(name=selection$name, type=selection$type, datapath=savefile)
+    type <- selection$type
+    if (is.null(type)) {
+        type <- ""
+    }
+    data.frame(name=selection$name, type=type, datapath=savefile, stringsAsFactors = FALSE)
 }

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -26,7 +26,8 @@ NULL
 #' 
 #' @importFrom shiny observe invalidateLater
 #' 
-shinyFileSave <- function(input, id, updateFreq=2000, session=getSession(), ...) {
+shinyFileSave <- function(input, id, updateFreq=2000, session=getSession(),
+                          defaultPath='', defaultRoot=NULL, ...) {
     fileGet <- do.call('fileGetter', list(...))
     dirCreate <- do.call('dirCreator', list(...))
     currentDir <- list()
@@ -41,7 +42,7 @@ shinyFileSave <- function(input, id, updateFreq=2000, session=getSession(), ...)
             lastDirCreate <<- createDir
         }
         if(is.null(dir) || is.na(dir)) {
-            dir <- list(dir='')
+            dir <- list(dir=defaultPath, root=defaultRoot)
         } else {
             dir <- list(dir=dir$path, root=dir$root)
         }

--- a/inst/example/server.R
+++ b/inst/example/server.R
@@ -3,7 +3,8 @@ library(shinyFiles)
 
 shinyServer(function(input, output, session) {
     volumes <- c('R Installation'=R.home())
-    shinyFileChoose(input, 'file', roots=volumes, session=session, restrictions=system.file(package='base'))
+    shinyFileChoose(input, 'file', roots=volumes, session=session, restrictions=system.file(package='base'),
+                    defaultRoot = 'R Installation', defaultPath = 'library')
     shinyDirChoose(input, 'directory', roots=volumes, session=session, restrictions=system.file(package='base'))
     shinyFileSave(input, 'save', roots=volumes, session=session, restrictions=system.file(package='base'))
     output$filepaths <- renderPrint({parseFilePaths(volumes, input$file)})

--- a/inst/example/ui.R
+++ b/inst/example/ui.R
@@ -20,7 +20,8 @@ shinyUI(pageWithSidebar(
         tags$p('The file selection button allows the user to select one or
                several files and get their absolute position communicated back
                to the shiny server. In this example the button has been set to
-               single-file mode.'),
+               single-file mode and the default path has been set to the "library"
+               subdirectory of the "R Installation" path.'),
         tags$hr(),
         shinyDirButton('directory', 'Folder select', 'Please select a folder'),
         tags$p(),

--- a/man/shinyFiles-observers.Rd
+++ b/man/shinyFiles-observers.Rd
@@ -7,11 +7,14 @@
 \alias{shinyFiles-observers}
 \title{Create a connection to the server side filesystem}
 \usage{
-shinyFileChoose(input, id, updateFreq = 2000, session = getSession(), ...)
+shinyFileChoose(input, id, updateFreq = 2000, session = getSession(),
+  defaultRoot = NULL, defaultPath = "", ...)
 
-shinyDirChoose(input, id, updateFreq = 2000, session = getSession(), ...)
+shinyDirChoose(input, id, updateFreq = 2000, session = getSession(),
+  defaultPath = "", defaultRoot = NULL, ...)
 
-shinyFileSave(input, id, updateFreq = 2000, session = getSession(), ...)
+shinyFileSave(input, id, updateFreq = 2000, session = getSession(),
+  defaultPath = "", defaultRoot = NULL, ...)
 }
 \arguments{
 \item{input}{The input object of the \code{shinyServer()} call (usaully 
@@ -28,6 +31,12 @@ files or drives)}
 
 \item{session}{The session object of the shinyServer call (usually 
 \code{session}).}
+
+\item{defaultRoot}{The default root to use. For instance if 
+\code{roots = c('wd' = '.', 'home', '/home')} then \code{defaultRoot} 
+can be either \code{'wd'} or \code{'home'}.}
+
+\item{defaultPath}{The default relative path specified given the \code{defaultRoot}.}
 
 \item{...}{Arguments to be passed on to \code{\link{fileGetter}} or 
 \code{\link{dirGetter}}}
@@ -72,7 +81,8 @@ ui <- shinyUI(bootstrapPage(
     shinyFilesButton('files', 'File select', 'Please select a file', FALSE)
 ))
 server <- shinyServer(function(input, output) {
-    shinyFileChoose(input, 'files', roots=c(wd='.'), filetypes=c('', 'txt'))
+    shinyFileChoose(input, 'files', roots=c(wd='.'), filetypes=c('', 'txt'),
+                    defaultPath='', defaultRoot='wd')
 })
 
 runApp(list(


### PR DESCRIPTION
This PR partially deals with #37 by providing a way to define the initial path of a button.

The user can provide the default root (or volume) and the default path under that root.

(Note that this PR also includes #47 as I have been working on both issues)
