### PR TITLE
Enable addition of an icon for shinyFilesButton and shinySaveButton

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -328,7 +328,7 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session = getSession(), 
 #' 
 #' @export
 #' 
-shinyFilesButton <- function(id, label, title, multiple, buttonType='default', class=NULL) {
+shinyFilesButton <- function(id, label, title, multiple, buttonType='default', class=NULL, icon=NULL) {
     tagList(
         singleton(tags$head(
                 tags$script(src='sF/shinyFiles.js'),
@@ -349,7 +349,7 @@ shinyFilesButton <- function(id, label, title, multiple, buttonType='default', c
             class=paste(c('shinyFiles btn', paste0('btn-', buttonType), class), collapse=' '),
             'data-title'=title,
             'data-selecttype'=ifelse(multiple, 'multiple', 'single'),
-            as.character(label)
+            list(icon, label)
             )
         )
 }

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -60,7 +60,7 @@ shinyFileSave <- function(input, id, updateFreq=2000, session=getSession(), ...)
 #' 
 #' @export
 #' 
-shinySaveButton <- function(id, label, title, filetype, buttonType='default', class=NULL) {
+shinySaveButton <- function(id, label, title, filetype, buttonType='default', class=NULL, icon=NULL) {
     if(missing(filetype)) filetype <- NA
     filetype <- formatFiletype(filetype)
     
@@ -84,7 +84,7 @@ shinySaveButton <- function(id, label, title, filetype, buttonType='default', cl
             class=paste(c('shinySave btn', paste0('btn-', buttonType), class), collapse=' '),
             'data-title'=title,
             'data-filetype'=filetype,
-            as.character(label)
+            list(icon, label)
         )
     )
 }


### PR DESCRIPTION
User can add an icon for `shinyFilesButton` and `shinySaveButton` similar to [`actionButton`](https://github.com/rstudio/shiny/blob/9613c58bf8120bcfdab35801b17167418b5464ac/R/input-action.R#L41).
(see #26)