### PR TITLE
Add optional icon to shinyFilesButton and shinySaveButton

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -309,6 +309,8 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session = getSession(), 
 #' 
 #' @param class Additional classes added to the button
 #' 
+#' @param icon An optional \href{http://shiny.rstudio.com/reference/shiny/latest/icon.html}{icon} to appear on the button.
+#' 
 #' @param filetype A named list of file extensions. The name of each element 
 #' gives the name of the filetype and the content of the element the possible
 #' extensions e.g. \code{list(picture=c('jpg', 'jpeg'))}. The first extension
@@ -328,7 +330,7 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session = getSession(), 
 #' 
 #' @export
 #' 
-shinyFilesButton <- function(id, label, title, multiple, buttonType='default', class=NULL) {
+shinyFilesButton <- function(id, label, title, multiple, buttonType='default', class=NULL, icon=NULL) {
     tagList(
         singleton(tags$head(
                 tags$script(src='sF/shinyFiles.js'),
@@ -349,7 +351,7 @@ shinyFilesButton <- function(id, label, title, multiple, buttonType='default', c
             class=paste(c('shinyFiles btn', paste0('btn-', buttonType), class), collapse=' '),
             'data-title'=title,
             'data-selecttype'=ifelse(multiple, 'multiple', 'single'),
-            as.character(label)
+            list(icon, label)
             )
         )
 }

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -60,7 +60,7 @@ shinyFileSave <- function(input, id, updateFreq=2000, session=getSession(), ...)
 #' 
 #' @export
 #' 
-shinySaveButton <- function(id, label, title, filetype, buttonType='default', class=NULL) {
+shinySaveButton <- function(id, label, title, filetype, buttonType='default', class=NULL, icon=NULL) {
     if(missing(filetype)) filetype <- NA
     filetype <- formatFiletype(filetype)
     
@@ -84,7 +84,7 @@ shinySaveButton <- function(id, label, title, filetype, buttonType='default', cl
             class=paste(c('shinySave btn', paste0('btn-', buttonType), class), collapse=' '),
             'data-title'=title,
             'data-filetype'=filetype,
-            as.character(label)
+            list(icon, label)
         )
     )
 }

--- a/man/shinyFiles-buttons.Rd
+++ b/man/shinyFiles-buttons.Rd
@@ -8,12 +8,12 @@
 \title{Create a button to summon a shinyFiles dialog}
 \usage{
 shinyFilesButton(id, label, title, multiple, buttonType = "default",
-  class = NULL)
+  class = NULL, icon = NULL)
 
 shinyDirButton(id, label, title, buttonType = "default", class = NULL)
 
 shinySaveButton(id, label, title, filetype, buttonType = "default",
-  class = NULL)
+  class = NULL, icon = NULL)
 }
 \arguments{
 \item{id}{The id matching the \code{\link{shinyFileChoose}}}
@@ -31,6 +31,8 @@ Defaults to 'default' for a neutral appearance but can be changed for another
 look. The value will be pasted with 'btn-' and added as class.}
 
 \item{class}{Additional classes added to the button}
+
+\item{icon}{An optional \href{http://shiny.rstudio.com/reference/shiny/latest/icon.html}{icon} to appear on the button.}
 
 \item{filetype}{A named list of file extensions. The name of each element 
 gives the name of the filetype and the content of the element the possible


### PR DESCRIPTION
User can add an optional [`icon`](http://shiny.rstudio.com/reference/shiny/latest/icon.html) for `shinyFilesButton` and `shinySaveButton` similar to [`actionButton`](https://github.com/rstudio/shiny/blob/9613c58bf8120bcfdab35801b17167418b5464ac/R/input-action.R#L41).
(see #26)
