### PR TITLE
Fixing issue #62

### DIFF
--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1367,7 +1367,7 @@ var shinyFiles = (function() {
             return false;
         })
         modal.find('.sF-newDir ul button').on('click', function() {
-            var name = $(this).closest('input-group').find('input').val();
+            var name = $(this).closest('.input-group').find('input').val();
             createFolder(name, modal);
         })
         


### PR DESCRIPTION
.closest() should use dot with the class name; this fixes the issue where clicking the 'plus' button to create a directory crashes the app. Please refer #62 