### PR TITLE
Parse file paths when selection$files is empty

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -485,7 +485,7 @@ shinyFilesLink <- function(id, label, title, multiple, class=NULL, icon=NULL) {
 parseFilePaths <- function(roots, selection) {
   roots <- if (class(roots) == "function") roots() else roots
 
-  if (is.null(selection) || is.na(selection) || is.integer(selection)) {
+  if (is.null(selection) || is.na(selection) || is.integer(selection) || length(selection$files) == 0) {
     data.frame(
       name = character(0), size = numeric(0), type = character(0),
       datapath = character(0), stringsAsFactors = FALSE

--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -54,10 +54,7 @@ fileGetter <- function(roots, restrictions, filetypes, pattern, hidden=FALSE) {
     if (is.null(root)) root <- names(currentRoots)[1]
 
     ## drop paths with only "" to avoid //
-    dropEmpty <- function(x) x[!vapply(x, function(x) nchar(x) == 0, FUN.VALUE = logical(1))]
     fulldir <- file.path(currentRoots[root], dropEmpty(dir))
-
-    dropEmpty <- function(x) x[!vapply(x, function(x) nchar(x) == 0, FUN.VALUE = logical(1))]
     fulldir <- do.call("file.path", as.list(dropEmpty(c(currentRoots[root], dir))))
     writable <- as.logical(file.access(fulldir, 2) == 0)
     files <- list.files(fulldir, all.files = hidden, full.names = TRUE, no.. = TRUE)

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -479,13 +479,6 @@ var shinyFiles = (function() {
       dismissFileChooser(button, modal)
     })
 
-    // working but if you open and close a few times you get an error (see PR) 
-    // $(document).keyup(function(e) {
-    //   if (e.which == 27) {
-    //     dismissFileChooser(button, modal)
-    //   }
-    // });
-
     modal.find('.sF-responseButtons #sF-cancelButton').on('click', function() {
       dismissFileChooser(button, modal);
     })
@@ -544,13 +537,6 @@ var shinyFiles = (function() {
         elementSelector(event, this, single, false);
         selectFiles(button, modal);
       })
-      // not working
-      // .on('keyup', '.sF-directory', function(event) {
-      //   if (event.keyCode == 13) {
-      //     $(this).toggleClass('selected', true);
-      //     openDir($(element), modal, this);
-      //   }
-      // })
       .on('click', '.sF-file, .sF-directory', function(event) {
         var single = $(button).data('selecttype') == 'single';
         elementSelector(event, this, single, false);
@@ -1104,14 +1090,6 @@ var shinyFiles = (function() {
       modal.trigger('change');
     })
 
-    // not working
-    // modal.find('.sF-filename input').on('keyup', function(e) {
-    //   var disabled = $(this).val() == '';
-    //   if (e.keyCode == 13) {
-    //     saveFile(modal, button)
-    //   }
-    // })
-    
     // Custom events
     modal
       .on('change', function() {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -479,6 +479,13 @@ var shinyFiles = (function() {
       dismissFileChooser(button, modal)
     })
 
+    // working but if you open and close a few times you get an error (see PR) 
+    // $(document).keyup(function(e) {
+    //   if (e.which == 27) {
+    //     dismissFileChooser(button, modal)
+    //   }
+    // });
+
     modal.find('.sF-responseButtons #sF-cancelButton').on('click', function() {
       dismissFileChooser(button, modal);
     })
@@ -537,6 +544,13 @@ var shinyFiles = (function() {
         elementSelector(event, this, single, false);
         selectFiles(button, modal);
       })
+      // not working
+      // .on('keyup', '.sF-directory', function(event) {
+      //   if (event.keyCode == 13) {
+      //     $(this).toggleClass('selected', true);
+      //     openDir($(element), modal, this);
+      //   }
+      // })
       .on('click', '.sF-file, .sF-directory', function(event) {
         var single = $(button).data('selecttype') == 'single';
         elementSelector(event, this, single, false);
@@ -670,6 +684,7 @@ var shinyFiles = (function() {
           return oldFiles[$(this).find('.sF-file-name div').text()]
         }).remove();
       };
+      
       if (Object.keys(newFiles).length === 0) {
         for (i in newFiles) {
           var d = newFiles[i];
@@ -1089,6 +1104,14 @@ var shinyFiles = (function() {
       modal.trigger('change');
     })
 
+    // not working
+    // modal.find('.sF-filename input').on('keyup', function(e) {
+    //   var disabled = $(this).val() == '';
+    //   if (e.keyCode == 13) {
+    //     saveFile(modal, button)
+    //   }
+    // })
+    
     // Custom events
     modal
       .on('change', function() {


### PR DESCRIPTION
I ran into an issue several time where an app would gray-out because `selection$files` was empty. You can add code in the app to catch this scenario but it seems cleaner just to add the condition to `parseFilePaths`