### PR TITLE
Force select on file double click

### DIFF
--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -534,7 +534,7 @@ var shinyFiles = (function() {
       })
       .on('dblclick', '.sF-file', function(event) {
         var single = $(button).data('selecttype') == 'single';
-        elementSelector(event, this, single, false);
+        elementSelector(event, this, single, true);
         selectFiles(button, modal);
       })
       .on('click', '.sF-file, .sF-directory', function(event) {


### PR DESCRIPTION
When selecting files, the 'dblclick' event now triggers a call to `elementSelector` with `forceSelect` set to `true`. This means, regardless of the status of the file that was double-clicked (selected or not) before the double-click, elementSelector will select the file.