### PR TITLE
Modal UI additional features

### DIFF
--- a/R/dirchoose.R
+++ b/R/dirchoose.R
@@ -197,7 +197,7 @@ shinyDirChoose <- function(input, id, updateFreq = 0, session=getSession(),
   lastDirCreate <- NULL
   clientId <- session$ns(id)
   
-  observe({
+  sendDirectoryData <- function(message) {
     req(input[[id]])
     tree <- input[[paste0(id, "-modal")]]
     createDir <- input[[paste0(id, "-newDir")]]
@@ -225,8 +225,18 @@ shinyDirChoose <- function(input, id, updateFreq = 0, session=getSession(),
       newDir$writable <- content$writable
     }
     currentDir <<- newDir
-    session$sendCustomMessage("shinyDirectories", list(id = clientId, dir = newDir))
+    session$sendCustomMessage(message, list(id = clientId, dir = newDir))
     if (updateFreq > 0) invalidateLater(updateFreq, session)
+  }
+
+  observe({
+    sendDirectoryData("shinyDirectories")
+  })
+
+  observeEvent(input[[paste0(id, "-refresh")]], {
+    if (!is.null(input[[paste0(id, "-refresh")]])) {
+      sendDirectoryData("shinyDirectories-refresh")
+    }
   })
 }
 #' @rdname shinyFiles-buttons

--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -192,7 +192,7 @@ shinyFileChoose <- function(input, id, updateFreq = 0, session = getSession(),
   currentDir <- list()
   clientId <- session$ns(id)
 
-  observe({
+  sendDirectoryData <- function(message) {
     req(input[[id]])
     dir <- input[[paste0(id, "-modal")]]
     if (is.null(dir) || is.na(dir)) {
@@ -205,8 +205,18 @@ shinyFileChoose <- function(input, id, updateFreq = 0, session = getSession(),
     fileGet <- do.call(fileGetter, list(...))
     newDir <- do.call(fileGet, dir)
     currentDir <<- newDir
-    session$sendCustomMessage("shinyFiles", list(id = clientId, dir = newDir))
+    session$sendCustomMessage(message, list(id = clientId, dir = newDir))
     if (updateFreq > 0) invalidateLater(updateFreq, session)
+  }
+
+  observe({
+    sendDirectoryData("shinyFiles")
+  })
+
+  observeEvent(input[[paste0(id, "-refresh")]], {
+    if (!is.null(input[[paste0(id, "-refresh")]])) {
+      sendDirectoryData("shinyFiles-refresh")
+    }
   })
 }
 

--- a/R/filesave.R
+++ b/R/filesave.R
@@ -34,7 +34,7 @@ shinyFileSave <- function(input, id, updateFreq=0, session=getSession(),
   lastDirCreate <- NULL
   clientId <- session$ns(id)
 
-  observe({
+  sendDirectoryData <- function(message) {
     req(input[[id]])
     dir <- input[[paste0(id, "-modal")]]
     createDir <- input[[paste0(id, "-newDir")]]
@@ -51,9 +51,19 @@ shinyFileSave <- function(input, id, updateFreq=0, session=getSession(),
     newDir <- do.call(fileGet, dir)
     if (isTRUE(newDir$exist)) {
       currentDir <<- newDir
-      session$sendCustomMessage("shinySave", list(id = clientId, dir = newDir))
+      session$sendCustomMessage(message, list(id = clientId, dir = newDir))
     }
     if (updateFreq > 0) invalidateLater(updateFreq, session)
+  }
+
+  observe({
+    sendDirectoryData("shinySave")
+  })
+
+  observeEvent(input[[paste0(id, "-refresh")]], {
+    if (!is.null(input[[paste0(id, "-refresh")]])) {
+      sendDirectoryData("shinySave-refresh")
+    }
   })
 }
 #' @rdname shinyFiles-buttons

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -36,8 +36,8 @@ var shinyFiles = (function() {
 
       if (topOffset < scrollPosition) {
         $('.sF-fileWindow')[0].scrollTop = topOffset;
-      } else if (topOffset > scrollPosition + $('.sF-fileWindow').height() - parent.children()[1].offsetTop) {
-        $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').innerHeight() + $(element).outerHeight();
+      } else if (topOffset + $(element).outerHeight(true) > scrollPosition + $('.sF-fileWindow').height()) {
+        $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').height() + $(element).outerHeight(true);
       }
     }
   
@@ -76,7 +76,9 @@ var shinyFiles = (function() {
 
     // No element is currently selected, return without action
     // if (!$(currentElement).hasClass('selected')) {
-    if (!('lastElement' in parent.data())) {
+    if (!('lastElement' in parent.data())
+        || parent.data('lastElement') === null
+        || !$(parent.data('lastElement')).is(":visible")) {
       // Start on the first element if none are currently selected.
       var newElement = parent.children()[1];
       elementSelector(event, newElement, single, true);
@@ -119,7 +121,7 @@ var shinyFiles = (function() {
       if (direction === "up") {
         var newIndex = endIndex - numAcross;
 
-        if (newIndex < 0) { invalidFlag = true; }
+        if (newIndex < 1) { invalidFlag = true; }
       }
 
       if (direction === "down") {
@@ -150,7 +152,7 @@ var shinyFiles = (function() {
       if (direction === "up") {
         newIndex = ends[0] - numAcross;
 
-        if (newIndex < 0) { invalidFlag = true; }
+        if (newIndex < 1) { invalidFlag = true; }
       }
 
       if (direction === "down") {
@@ -164,8 +166,6 @@ var shinyFiles = (function() {
       var newElement = parent.children()[newIndex];
 
       elementSelector(event, newElement, single, true);
-    } else {
-      console.log("WOMP");
     }
   };
   

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1906,6 +1906,25 @@ var shinyFiles = (function() {
           }
 
           break;
+        case 13:
+          // Enter
+          if ($(".sF-modalContainer").is(":visible") && ("lastElement" in $(".sF-fileList").data())) {
+            var lastElement = $(".sF-fileList").data('lastElement');
+            if ($($(".sF-fileList").data('lastElement')).hasClass('selected')) {
+              var modalType;
+              var modalButton = $($(".sF-modalContainer").data('button'));
+              if (modalButton.hasClass("shinyFiles")) {
+                // Select File
+                selectFiles(modalButton, $(".sF-modalContainer"));
+              } else if (modalButton.hasClass("shinySave")) {
+                // Select Directory
+                saveFile(modalButton, $(".sF-modalContainer"));
+              } else if (modalButton.hasClass("shinyDirectories")) {
+                // Save File
+                selectFolder($(".sF-dirList"), $(".sF-modalContainer"), modalButton);
+              }
+            }
+          }
       }
     });
 

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -42,6 +42,7 @@ var shinyFiles = (function() {
         var viewType = button.data('view');
 
         if (viewType === "sF-btn-icon") {
+          // Vertical scroll
           var topOffset = $(element)[0].offsetTop - parent.children()[1].offsetTop;
           var scrollPosition = $('.sF-fileWindow')[0].scrollTop;
 
@@ -51,7 +52,7 @@ var shinyFiles = (function() {
             $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').height() + $(element).outerHeight(true);
           }
         } else if (viewType === "sF-btn-list") {
-          // Lists scroll left to right, but otherwise the logic is very similar to icons
+          // Lists scroll horizontally, but otherwise the logic is very similar to icons
           var leftOffset = $(element)[0].offsetLeft - parent.children()[1].offsetLeft;
           var scrollPosition = $('.sF-fileWindow')[0].scrollLeft;
 
@@ -61,7 +62,15 @@ var shinyFiles = (function() {
             $('.sF-fileWindow')[0].scrollLeft = leftOffset - $('.sF-fileWindow').width() + $(element).outerWidth(true);
           }
         } else if (viewType === "sF-btn-detail") {
+          // Essentially the same as icons, but header is visible
+          var topOffset = $(element)[0].offsetTop - parent.children()[0].offsetTop;
+          var scrollPosition = $('.sF-fileWindow')[0].scrollTop;
 
+          if (topOffset < scrollPosition) {
+            $('.sF-fileWindow')[0].scrollTop = topOffset;
+          } else if (topOffset + $(element).outerHeight(true) > scrollPosition + $('.sF-fileWindow').height()) {
+            $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').height() + $(element).outerHeight(true)
+          }
         }
       } else if (dirFlag) {
 

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1872,7 +1872,6 @@ var shinyFiles = (function() {
           break;
         case 37:
           // Left Arrow
-          console.log("LEFT");
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "left");
@@ -1882,7 +1881,6 @@ var shinyFiles = (function() {
           break;
         case 39:
           // Right Arrow
-          console.log("RIGHT");
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "right");
@@ -1892,7 +1890,6 @@ var shinyFiles = (function() {
           break;
         case 38:
           // Up arrow
-          console.log("UP");
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "up");
@@ -1902,7 +1899,6 @@ var shinyFiles = (function() {
           break;
         case 40:
           // Down arrow
-          console.log("DOWN");
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "down");

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1,5 +1,4 @@
 var shinyFiles = (function() {
-    
   // General functionality
     
   var elementSelector = function(event, element, single, forceSelect) {
@@ -1762,6 +1761,13 @@ var shinyFiles = (function() {
       if ($("#sF-cancelButton").is(":visible") && event.keyCode == 27 && !$("div.sF-newDir").hasClass("open")) {
         $("#sF-cancelButton").click();
       };
+    });
+
+    // Close modal when clicking on backdrop
+    $(document).on('click', '.sF-modalContainer', function(e) {
+      if (!$(e.target).closest('.modal-content').length > 0 && $("#sF-cancelButton").is(":visible")) {
+        $("#sF-cancelButton").click();
+      }
     });
   };
   

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -846,6 +846,12 @@ var shinyFiles = (function() {
                 )
               )
             ).append(
+              $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
+                  $('<span>').addClass('glyphicon glyphicon-refresh')
+                )
+              )
+            ).append(
               $('<select>').addClass('sF-breadcrumps form-control input-sm')
             )
           ).append(
@@ -919,6 +925,13 @@ var shinyFiles = (function() {
     // Breadcrump and volume navigation
     modal.find('.sF-breadcrumps').on('change', function() {
       moveToDir(button, modal, this);
+    })
+
+    // Refresh
+    modal.find('.sF-refresh').on('click', function(event) {
+      event.preventDefault();
+      // populateFileChooser(button, $(button).data('dataCache'))
+      refreshDirectory(modal);
     })
         
     // File window
@@ -1158,6 +1171,12 @@ var shinyFiles = (function() {
     
     Shiny.onInputChange($(button).attr('id')+'-modal', directory);
   };
+
+  var refreshDirectory = function(modal) {
+    var directory = getCurrentDirectory(modal);
+    // Shiny.onInputChange($(modal.data('button')).attr('id')+'-modal', null);
+    // Shiny.onInputChange($(modal.data('button')).attr('id')+'-modal', directory);
+  }
   
   var moveBack = function(button, modal) {
     $('.sF-btn-back').prop('disabled', true);
@@ -1323,6 +1342,12 @@ var shinyFiles = (function() {
                 )
               )
             ).append(
+              $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
+                  $('<span>').addClass('glyphicon glyphicon-refresh')
+                )
+              )
+            ).append(
               $('<select>').addClass('sF-breadcrumps form-control input-sm')
             )
           ).append(
@@ -1417,6 +1442,12 @@ var shinyFiles = (function() {
         
         $(modal).trigger('fileSort', [$(this).parent().find('.selected a').text(), $(this).find('a').attr('class')])
       })
+
+    // Refresh
+    modal.find('.sF-refresh').on('click', function(e) {
+      e.preventDefault();
+      refreshDirectory(modal);
+    })
         
     // Breadcrump and volume navigation
     modal.find('.sF-breadcrumps').on('change', function() {
@@ -1709,6 +1740,12 @@ var shinyFiles = (function() {
                 )
               )
             ).append(
+              $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
+                  $('<span>').addClass('glyphicon glyphicon-refresh')
+                )
+              )
+            ).append(
               $('<select>').addClass('sF-breadcrumps form-control input-sm')
             )
           ).append(
@@ -1823,6 +1860,13 @@ var shinyFiles = (function() {
       .on('click', '.sF-file-icon, .sF-file-name', function(e) {
         selectFolder($(this), modal, button);
       })
+
+    // Refresh
+    modal.find('.sF-refresh').on('click', function(e) {
+      e.preventDefault();
+      // populateDirChooser(button, $(button).data('dataCache'));
+      refreshDirectory(modal);
+    })
     
     // Custom events
     modal
@@ -2159,7 +2203,9 @@ var shinyFiles = (function() {
   
   sF.init = function() {
     Shiny.addCustomMessageHandler('shinyFiles', function(data) {
+      console.log('data', data);
       populateFileChooser($('.shinyFiles#'+data.id), parseFiles(data.dir));
+      console.log('parsed', parseFiles(data.dir));
     });
     Shiny.addCustomMessageHandler('shinyDirectories', function(data) {
       populateDirChooser($('.shinyDirectories#'+data.id), data.dir);

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -168,7 +168,12 @@ var shinyFiles = (function() {
             down: Math.min(Math.ceil(endIndex / numVertical) * numVertical, lastItemIndex)
           };
         } else if (viewType === "sF-btn-detail") {
-          bounds = {};
+          bounds = {
+            left: 1,
+            right: lastItemIndex,
+            up: 1,
+            right: lastItemIndex
+          };
         }
 
         newIndex = endIndex;
@@ -216,12 +221,18 @@ var shinyFiles = (function() {
         } else if (viewType === "sF-btn-detail") {
           switch (direction) {
             case "left":
+              invalidFlag = true;
               break;
             case "right":
+              invalidFlag = true;
               break;
             case "up":
+              newIndex = endIndex - 1;
+              if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
+              newIndex = endIndex + 1;
+              if (newIndex > bounds.down) { invalidFlag = true; }
               break;
           }
         }
@@ -241,7 +252,12 @@ var shinyFiles = (function() {
             down: Math.min(Math.ceil(ends[1] / numVertical) * numVertical, lastItemIndex)
           };
         } else if (viewType === "sF-btn-detail") {
-          bounds = {};
+          bounds = {
+            left: 1,
+            right: lastItemIndex,
+            up: 1,
+            down: lastItemIndex,
+          };
         }
 
         // Slightly different behavior when switching to a single selection
@@ -290,12 +306,18 @@ var shinyFiles = (function() {
         } else if (viewType === "sF-btn-detail") {
           switch (direction) {
             case "left":
+              invalidFlag = true;
               break;
             case "right":
+              invalidFlag = true;
               break;
             case "up":
+              newIndex = ends[0] - 1;
+              if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
+              newIndex = ends[1] + 1;
+              if (newIndex > bounds.down)  { invalidFlag = true; }
               break;
           }
         }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -323,7 +323,12 @@ var shinyFiles = (function() {
         elementSelector(event, newElement, single, true);
 
         if (button.hasClass("shinySave")) {
-          var filename = $(newElement).find('.sF-file-name>div').text();
+          if (!$(newElement).hasClass('sF-directory')) {
+            var filename = $(newElement).find('.sF-file-name>div').text();
+          } else {
+            var filename = '';
+          }
+
           setFilename(modal, filename);
         }
 

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -2208,13 +2208,13 @@ var shinyFiles = (function() {
   
   sF.init = function() {
     Shiny.addCustomMessageHandler('shinyFiles', function(data) {
-      populateFileChooser($('.shinyFiles#'+data.id), parseFiles(data.dir), false);
+      populateFileChooser($('.shinyFiles#'+data.id), parseFiles(data.dir), true);
     });
     Shiny.addCustomMessageHandler('shinyDirectories', function(data) {
       populateDirChooser($('.shinyDirectories#'+data.id), data.dir);
     });
     Shiny.addCustomMessageHandler('shinySave', function(data) {
-      populateFileChooser($('.shinySave#'+data.id), parseFiles(data.dir), false);
+      populateFileChooser($('.shinySave#'+data.id), parseFiles(data.dir), true);
     });
 
     Shiny.addCustomMessageHandler('shinyFiles-refresh', function(data) {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -377,7 +377,10 @@ var shinyFiles = (function() {
             // Close expanded directory
             toggleExpander($(currentElement.find('.sF-expander>span')[0]), modal, button);
             return;
-          } else {
+          } else if (currentElement.hasClass("empty") || currentElement.hasClass("closed")) {
+            newElement = $(parentDir(currentElement));
+            selectFolder($(newElement[0]), modal, button);
+            toggleExpander($($(parentDir(currentElement)).find('.sF-expander>span')[0]), modal, button);
             return;
           }
 

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -2048,37 +2048,26 @@ var shinyFiles = (function() {
   };
     
   var toggleExpander = function(element, modal, button) {
-    console.log("yop");
-    console.log("element", element);
     var parent = $(element.closest('.sF-directory')[0]);
-    console.log("parent", parent);
+
     if(!parent.hasClass('empty')) {
-      console.log("good a");
       var path = getPath(element);
-      console.log(path);
       if(parent.find('.selected').length != 0) {
-        console.log("huh");
         modal.data('currentData').contentPath = path.slice();
       }
       path.shift();
       if (modal.data('currentData') && modal.data('currentData').tree) {
-        console.log("b");
         var tree = modal.data('currentData').tree;
         while(true) {
-          console.log("ccccc");
           if(path.length == 0) {
-            console.log('d');
             tree.expanded = !tree.expanded;
             break;
           } else {
-            console.log("e");
             var name = path.shift();
             tree = tree.children.filter(function(f) {
               if (f == null) {
-                console.log("f");
                 return null;
               } else {
-                console.log("g");
                 return f.name == name;
               }
             })[0];

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -2290,7 +2290,7 @@ var shinyFiles = (function() {
                 var parts = filename.split(".");
 
                 // Do not use enter to submit an empty filename (just a file extension)
-                if (parts.slice(0,parts.length-1).join(".").length > 0) {
+                if (($(".sF-filetype").length > 0 && filename.length > 0) || parts.slice(0,parts.length-1).join(".").length > 0) {
                   saveFile($('.sF-modalContainer'), modalButton);
                 }
               } else if ($($(".sF-fileList").data('lastElement')).hasClass('sF-directory')) {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -327,6 +327,11 @@ var shinyFiles = (function() {
         var newElement = parent.children()[newIndex];
         elementSelector(event, newElement, single, true);
 
+        if (button.hasClass("shinySave")) {
+          var filename = $(newElement).find('.sF-file-name>div').text();
+          setFilename(modal, filename);
+        }
+
         if (!single && event.shiftKey) {
           // Preserve 'lastElement' during multi-selection, ensuring an anchor is consistent
           parent.data('lastElement', currentElement);
@@ -2023,6 +2028,16 @@ var shinyFiles = (function() {
     Shiny.onInputChange($(button).attr('id')+'-modal', data);
   };
   // Directory chooser ends
+
+  var handleArrowKey = function(direction) {
+    var modal = $('.sF-modalContainer');
+    if (modal.is(":visible") && !($(modal.data('button')).hasClass("shinySave") && $('.sF-filename').is(":focus"))) {
+      var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
+      moveSelection(event, single, direction);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
     
   var sF = {};
   
@@ -2067,43 +2082,19 @@ var shinyFiles = (function() {
           break;
         case 37:
           // Left Arrow
-          if ($(".sF-modalContainer").is(":visible")) {
-            var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
-            moveSelection(event, single, "left");
-            event.preventDefault();
-            event.stopPropagation();
-          }
-
+          handleArrowKey("left");
           break;
         case 39:
           // Right Arrow
-          if ($(".sF-modalContainer").is(":visible")) {
-            var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
-            moveSelection(event, single, "right");
-            event.preventDefault();
-            event.stopPropagation();
-          }
-
+          handleArrowKey("right");
           break;
         case 38:
           // Up arrow
-          if ($(".sF-modalContainer").is(":visible")) {
-            var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
-            moveSelection(event, single, "up");
-            event.preventDefault();
-            event.stopPropagation();
-          }
-
+          handleArrowKey("up");
           break;
         case 40:
           // Down arrow
-          if ($(".sF-modalContainer").is(":visible")) {
-            var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
-            moveSelection(event, single, "down");
-            event.preventDefault();
-            event.stopPropagation();
-          }
-
+          handleArrowKey("down");
           break;
         case 13:
           // Enter
@@ -2120,9 +2111,11 @@ var shinyFiles = (function() {
                   openDir(modalButton, $(".sF-modalContainer"), $($(".sF-fileList").data('lastElement')));
                 }
               } else if (modalButton.hasClass("shinySave")) {
-                // Select Directory
-                console.log("TBD");
-                // saveFile(modalButton, $(".sF-modalContainer"));
+                if ($('.sF-filename').is(":focus") || $($(".sF-fileList").data('lastElement')).hasClass('sF-file')) {
+                  saveFile($('.sF-modalContainer'), modalButton);
+                } else if ($($(".sF-fileList").data('lastElement')).hasClass('sF-directory')) {
+                  openDir(modalButton, $(".sF-modalContainer"), $($(".sF-fileList").data('lastElement')));
+                }
               } else if (modalButton.hasClass("shinyDirectories")) {
                 // Save File
                 console.log("TBD");

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -51,7 +51,15 @@ var shinyFiles = (function() {
             $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').height() + $(element).outerHeight(true);
           }
         } else if (viewType === "sF-btn-list") {
+          // Lists scroll left to right, but otherwise the logic is very similar to icons
+          var leftOffset = $(element)[0].offsetLeft - parent.children()[1].offsetLeft;
+          var scrollPosition = $('.sF-fileWindow')[0].scrollLeft;
 
+          if (leftOffset < scrollPosition) {
+            $('.sF-fileWindow')[0].scrollLeft = leftOffset;
+          } else if (leftOffset + $(element).outerWidth(true) > scrollPosition + $('.sF-fileWindow').width()) {
+            $('.sF-fileWindow')[0].scrollLeft = leftOffset - $('.sF-fileWindow').width() + $(element).outerWidth(true);
+          }
         } else if (viewType === "sF-btn-detail") {
 
         }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -2267,6 +2267,7 @@ var shinyFiles = (function() {
           handleArrowKey("down");
           break;
         case 13:
+
           // Enter
           if ($(".sF-modalContainer").is(":visible")) {
             var modalButton = $($(".sF-modalContainer").data('button'));
@@ -2283,11 +2284,11 @@ var shinyFiles = (function() {
               }
             } else if (modalButton.hasClass("shinySave")) {
               // Assume the button is properly disabled/enabled
-              if ($("#sF-selectButton").prop('disabled')) { return; }
-
               if ($('.sF-filename').is(":focus") || $($(".sF-fileList").data('lastElement')).hasClass('sF-file')) {
                 var filename = $(".sF-filename").val();
                 var parts = filename.split(".");
+
+                if ($("#sF-selectButton").prop('disabled')) { return; }
 
                 // Do not use enter to submit an empty filename (just a file extension)
                 if (($(".sF-filetype").length > 0 && filename.length > 0) || parts.slice(0,parts.length-1).join(".").length > 0) {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -73,7 +73,7 @@ var shinyFiles = (function() {
           }
         }
       } else if (dirFlag) {
-
+        console.log("No Directory Modal support yet");
       } else {
         console.warn("Unknown type of modal");
       }
@@ -135,9 +135,12 @@ var shinyFiles = (function() {
       var ends = [originIndex, endIndex].sort();
 
       // Number of icons that fit with the file list, left to right
-      var boundingWidth = $(".sF-fileList.sF-icons").width();
-      var iconWidth = $(".sF-fileList.sF-icons>div").outerWidth(true);
-      var numAcross = Math.floor(boundingWidth / iconWidth);
+      var boundingWidth = $(".sF-fileWindow").width();
+      var boundingHeight = $(".sF-fileWindow").height();
+      var itemWidth = $(parent.children()[1]).outerWidth(true);
+      var itemHeight = $(parent.children()[1]).outerHeight(true);
+      var numHorizontal = Math.floor(boundingWidth / itemWidth);
+      var numVertical = Math.floor(boundingHeight / itemHeight);
       var lastItemIndex = parent.children().length - 1;  // Subtract 1 to account for header
 
       var viewType = button.data('view');
@@ -145,52 +148,69 @@ var shinyFiles = (function() {
 
       var invalidFlag = false;
 
+      var newIndex;
+
       // NOTE: The appropriate left/right/up/down position depends on whether shift is held
       // Dealing with a multi-selection
       if (!single && event.shiftKey) {
         if (viewType === "sF-btn-icon") {
           bounds = {
-            left: Math.max(((Math.ceil(endIndex / numAcross) - 1) * numAcross) + 1, 1),
-            right: Math.min(Math.ceil(endIndex / numAcross) * numAcross, lastItemIndex),
+            left: Math.max(((Math.ceil(endIndex / numHorizontal) - 1) * numHorizontal) + 1, 1),
+            right: Math.min(Math.ceil(endIndex / numHorizontal) * numHorizontal, lastItemIndex),
             up: 1,
             down: lastItemIndex
           };
         } else if (viewType === "sF-btn-list") {
-          bounds = {};
+          bounds = {
+            left: 1,
+            right: lastItemIndex,
+            up: Math.max(((Math.ceil(endIndex / numVertical) - 1) * numVertical) + 1, 1),
+            down: Math.min(Math.ceil(endIndex / numVertical) * numVertical, lastItemIndex)
+          };
         } else if (viewType === "sF-btn-detail") {
           bounds = {};
         }
+
+        newIndex = endIndex;
 
         // Find new index, if valid, based on movement direction.
         //    Does not move the original anchor, regardless of which item comes first in the list.
         if (viewType === "sF-btn-icon") {
           switch (direction) {
             case "left":
-              var newIndex = endIndex - 1;
+              newIndex = endIndex - 1;
               if (newIndex < bounds.left) { invalidFlag = true; }
               break;
             case "right":
-              var newIndex = endIndex + 1;
+              newIndex = endIndex + 1;
               if (newIndex > bounds.right) { invalidFlag = true; }
               break;
             case "up":
-              var newIndex = endIndex - numAcross;
+              newIndex = endIndex - numHorizontal;
               if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
-              var newIndex = endIndex + numAcross;
+              newIndex = endIndex + numHorizontal;
               if (newIndex > bounds.down) { invalidFlag = true; }
               break;
           }
         } else if (viewType === "sF-btn-list") {
           switch (direction) {
             case "left":
+              newIndex = endIndex - numVertical;
+              if (newIndex < bounds.left) { invalidFlag = true; }
               break;
             case "right":
+              newIndex = endIndex + numVertical;
+              if (newIndex > bounds.right) { invalidFlag = true; }
               break;
             case "up":
+              newIndex = endIndex - 1;
+              if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
+              newIndex = endIndex + 1;
+              if (newIndex > bounds.down) { invalidFlag = true; }
               break;
           }
         } else if (viewType === "sF-btn-detail") {
@@ -208,13 +228,18 @@ var shinyFiles = (function() {
       } else {
         if (viewType === "sF-btn-icon") {
           bounds = {
-            left: Math.max(((Math.ceil(ends[0] / numAcross) - 1) * numAcross) + 1, 1),
-            right: Math.min(Math.ceil(ends[1] / numAcross) * numAcross, lastItemIndex),
+            left: Math.max(((Math.ceil(ends[0] / numHorizontal) - 1) * numHorizontal) + 1, 1),
+            right: Math.min(Math.ceil(ends[1] / numHorizontal) * numHorizontal, lastItemIndex),
             up: 1,
             down: lastItemIndex
           };
         } else if (viewType === "sF-btn-list") {
-          bounds = {};
+          bounds = {
+            left: 1,
+            right: lastItemIndex,
+            up: Math.max(((Math.ceil(ends[0] / numVertical) - 1) * numVertical) + 1, 1),
+            down: Math.min(Math.ceil(ends[1] / numVertical) * numVertical, lastItemIndex)
+          };
         } else if (viewType === "sF-btn-detail") {
           bounds = {};
         }
@@ -222,7 +247,7 @@ var shinyFiles = (function() {
         // Slightly different behavior when switching to a single selection
         //    Left and Up move from the first item (index: ends[0])
         //    Right and Down move from the last item (index: ends[1])
-        var newIndex = originIndex;
+        newIndex = originIndex;
 
         if (viewType === "sF-btn-icon") {
           switch (direction) {
@@ -235,23 +260,31 @@ var shinyFiles = (function() {
               if (newIndex > bounds.right) { invalidFlag = true; }
               break;
             case "up":
-              newIndex = endIndex - numAcross;
+              newIndex = endIndex - numHorizontal;
               if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
-              newIndex = endIndex + numAcross;
+              newIndex = endIndex + numHorizontal;
               if (newIndex > bounds.down) { invalidFlag = true; }
               break;
           }
         } else if (viewType === "sF-btn-list") {
           switch (direction) {
             case "left":
+              newIndex = ends[0] - numVertical;
+              if (newIndex < bounds.left) { invalidFlag = true; }
               break;
             case "right":
+              newIndex = ends[1] + numVertical;
+              if (newIndex > bounds.right) { invalidFlag = true; }
               break;
             case "up":
+              newIndex = ends[0] - 1;
+              if (newIndex < bounds.up) { invalidFlag = true; }
               break;
             case "down":
+              newIndex = ends[1] + 1;
+              if (newIndex > bounds.down) { invalidFlag = true; }
               break;
           }
         } else if (viewType === "sF-btn-detail") {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -27,6 +27,18 @@ var shinyFiles = (function() {
     function clearAll() {
       parent.children().removeClass('selected');
     }
+
+    function scrollToSelected() {
+      // Adjust for any overall offsets
+      var topOffset = $(element)[0].offsetTop - parent.children()[1].offsetTop;
+      var scrollPosition = $('.sF-fileWindow')[0].scrollTop;
+
+      if (topOffset < scrollPosition) {
+        $('.sF-fileWindow')[0].scrollTop = topOffset;
+      } else if (topOffset > scrollPosition + $('.sF-fileWindow').height() - parent.children()[1].offsetTop) {
+        $('.sF-fileWindow')[0].scrollTop = topOffset - $('.sF-fileWindow').innerHeight() + $(element).outerHeight();
+      }
+    }
   
     // Use the same selector event for arrow key navigation
     if (event.button === 0 || event.type === "keydown") {
@@ -35,12 +47,15 @@ var shinyFiles = (function() {
         var nSelected = parent.children('.selected').length;
           clearAll();
           if ((!selected || nSelected != 1) || forceSelect) {
-            toggleSelection(element);               
+            toggleSelection(element);
+            scrollToSelected();              
           }
       } else if ((event.metaKey || event.ctrlKey) && !single) {
         toggleSelection(element);
+        scrollToSelected();
       } else if (event.shiftKey && !single) {
         selectElementsBetweenIndexes([$(lastSelectedElement).index(), $(element).index()]);
+        scrollToSelected();
       }
     }
   };
@@ -59,8 +74,12 @@ var shinyFiles = (function() {
     }
 
     // No element is currently selected, return without action
-    if (!$(currentElement).hasClass('selected')) {
-      return false;
+    // if (!$(currentElement).hasClass('selected')) {
+    if (!('lastElement' in parent.data())) {
+      // Start on the first element if none are currently selected.
+      var newElement = parent.children()[1];
+      elementSelector(event, newElement, single, true);
+      return;
     }
 
     var originIndex = $(currentElement).index(); // The original selected icon
@@ -140,9 +159,11 @@ var shinyFiles = (function() {
       }
     }
 
-    var newElement = parent.children()[newIndex];
+    if (!invalidFlag) {
+      var newElement = parent.children()[newIndex];
 
-    elementSelector(event, newElement, single, true);
+      elementSelector(event, newElement, single, true);
+    }
   };
   
   var compareArrays = function (arrayA, arrayB) {
@@ -1875,6 +1896,7 @@ var shinyFiles = (function() {
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "left");
+            event.preventDefault();
             event.stopPropagation();
           }
 
@@ -1884,6 +1906,7 @@ var shinyFiles = (function() {
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "right");
+            event.preventDefault();
             event.stopPropagation();
           }
 
@@ -1893,6 +1916,7 @@ var shinyFiles = (function() {
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "up");
+            event.preventDefault();
             event.stopPropagation();
           }
 
@@ -1902,6 +1926,7 @@ var shinyFiles = (function() {
           if ($(".sF-modalContainer").is(":visible")) {
             var single = $($(".sF-modalContainer").data('button')).data('selecttype') === "single";
             moveSelection(event, single, "down");
+            event.preventDefault();
             event.stopPropagation();
           }
 
@@ -1915,13 +1940,19 @@ var shinyFiles = (function() {
               var modalButton = $($(".sF-modalContainer").data('button'));
               if (modalButton.hasClass("shinyFiles")) {
                 // Select File
-                selectFiles(modalButton, $(".sF-modalContainer"));
+                if ($($(".sF-fileList").data('lastElement')).hasClass('sF-file')) {
+                  selectFiles(modalButton, $(".sF-modalContainer"));
+                } else if ($($(".sF-fileList").data('lastElement')).hasClass('sF-directory')) {
+                  openDir(modalButton, $(".sF-modalContainer"), $($(".sF-fileList").data('lastElement')));
+                }
               } else if (modalButton.hasClass("shinySave")) {
                 // Select Directory
-                saveFile(modalButton, $(".sF-modalContainer"));
+                console.log("TBD");
+                // saveFile(modalButton, $(".sF-modalContainer"));
               } else if (modalButton.hasClass("shinyDirectories")) {
                 // Save File
-                selectFolder($(".sF-dirList"), $(".sF-modalContainer"), modalButton);
+                console.log("TBD");
+                // selectFolder($(".sF-dirList"), $(".sF-modalContainer"), modalButton);
               }
             }
           }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -9,6 +9,7 @@ var shinyFiles = (function() {
       $(element).toggleClass('selected');
       parent.data('lastElement', element);
       parent.data('selectionEnd', null);
+      toggleSelectButton($('.sF-modalContainer'));
     }
     
     function selectElementsBetweenIndexes(indexes) {
@@ -163,6 +164,8 @@ var shinyFiles = (function() {
       var newElement = parent.children()[newIndex];
 
       elementSelector(event, newElement, single, true);
+    } else {
+      console.log("WOMP");
     }
   };
   

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1172,10 +1172,6 @@ var shinyFiles = (function() {
   };
 
   var refreshDirectory = function(modal) {
-    var directory = getCurrentDirectory(modal);
-    // Shiny.onInputChange($(modal.data('button')).attr('id')+'-modal', null);
-    // Shiny.onInputChange($(modal.data('button')).attr('id')+'-modal', directory);
-
     // Use timestamp to ensure change in value, triggering the backend observeEvent
     Shiny.onInputChange($(modal.data('button')).attr('id')+'-refresh', (new Date()).getTime());
   }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -2282,10 +2282,17 @@ var shinyFiles = (function() {
                 openDir(modalButton, $(".sF-modalContainer"), $($(".sF-fileList").data('lastElement')));
               }
             } else if (modalButton.hasClass("shinySave")) {
-              if (!$($(".sF-fileList").data('lastElement')).hasClass('selected')) { return; }
+              // Assume the button is properly disabled/enabled
+              if ($("#sF-selectButton").prop('disabled')) { return; }
 
               if ($('.sF-filename').is(":focus") || $($(".sF-fileList").data('lastElement')).hasClass('sF-file')) {
-                saveFile($('.sF-modalContainer'), modalButton);
+                var filename = $(".sF-filename").val();
+                var parts = filename.split(".");
+
+                // Do not use enter to submit an empty filename (just a file extension)
+                if (parts.slice(0,parts.length-1).join(".").length > 0) {
+                  saveFile($('.sF-modalContainer'), modalButton);
+                }
               } else if ($($(".sF-fileList").data('lastElement')).hasClass('sF-directory')) {
                 openDir(modalButton, $(".sF-modalContainer"), $($(".sF-fileList").data('lastElement')));
               }

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -63,6 +63,11 @@
   float: right;
 }
 
+.btn-toolbar .sF-breadcrumps {
+  margin-left: 5px;
+  float: left;
+}
+
 .btn-toolbar .btn-group {
   margin-bottom: 5px;
 }

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -32,7 +32,7 @@
 }
 
 .sF-breadcrumps {
-  width: calc(100% - 255px);
+  width: calc(100% - 300px);
   margin-left: auto
 }
 

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -59,6 +59,13 @@
   display: none;
 }
 
+.btn-toolbar .btn-group.sF-refresh {
+  float: right;
+}
+
+.btn-toolbar .btn-group {
+  margin-bottom: 5px;
+}
 
 /*
   Icons


### PR DESCRIPTION
Primarily addressing #79 .

Currently this is a work in progress.

Current features, at time of PR creation:

- Complete: Click outside of modal to close
- Complete: Arrow key navigation within shinyFiles modal (filechooser) and shinySave modal
- Complete: Enter to select/save file and open directories for shinyFiles and shinySave modals
- In progress: Arrow key navigation within shinyDirectories modal
- In progress: Enter key for selection of directory
- Potentially to come: Refresh button
