### PR TITLE
Fix issue when launched from within a shiny modal

### DIFF
--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -981,6 +981,11 @@ var shinyFiles = (function() {
     
     // Ready to enter
     setTimeout(function() {
+      if($('#shiny-modal').length ==0){
+        modal.detach().appendTo('body')
+      }else{
+        modal.detach().appendTo('#shiny-modal')
+      }
       modal.addClass('in');
       backdrop.addClass('in');
     }, 1);
@@ -1546,6 +1551,11 @@ var shinyFiles = (function() {
     
     // Ready to enter
     setTimeout(function() {
+      if($('#shiny-modal').length ==0){
+        modal.detach().appendTo('body')
+      }else{
+        modal.detach().appendTo('#shiny-modal')
+      }
       modal.addClass('in');
       backdrop.addClass('in');
     }, 1);
@@ -1902,6 +1912,11 @@ var shinyFiles = (function() {
           
     // Ready to enter
     setTimeout(function() {
+      if($('#shiny-modal').length ==0){
+        modal.detach().appendTo('body')
+      }else{
+        modal.detach().appendTo('#shiny-modal')
+      }
       modal.addClass('in');
       backdrop.addClass('in');
     }, 1);


### PR DESCRIPTION
This fixes an issue related to #101 where the filename text input could not be edited when launched from within a shiny modal. Here is a reproducible example:


```


library(shiny)
library(shinyFiles)
ui <- fluidPage(

    # Application title
    titlePanel("Old Faithful Geyser Data"),

    # Sidebar with a slider input for number of bins 
    flowLayout(
        actionButton("bt","nested"),
        shinyFiles::shinySaveButton("save_file2",
                                    "Save file2",
                                    "Save file2 as...",
                                    filetype = list(txt = "txt"))
    )
)

server <- function(input, output, session) {
    volumes <- c(Home = fs::path_home(), "R Installation" = R.home(), shinyFiles::getVolumes()())
    shinyFiles::shinyFileSave(input, "save_file", roots = volumes, session = session, restrictions = system.file(package = "base"))
    shinyFiles::shinyFileSave(input, "save_file2", roots = volumes, session = session, restrictions = system.file(package = "base"))
    
    observeEvent(input$bt,{
        d <- modalDialog(
            title="Save Document",
            size="l",
            actionButton("bt2","bt2")
        )
        showModal(d) 
    })    
    observeEvent(input$bt2,{
        d <- modalDialog(
            title="Save Document",
            size="l",
            shinyFiles::shinySaveButton("save_file",
                            "Save file",
                            "Save file as...",
                            filetype = list(txt = "txt"))
        )
        showModal(d) 
    })
}
# Run the application 
shinyApp(ui = ui, server = server)

```
