### PR TITLE
Check parent existence when attempting to navigate 'down' in directory selection

### DIFF
--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -428,7 +428,7 @@ var shinyFiles = (function() {
             do {
               nSib = nextSibling(parDir);
               parDir = parentDir(parDir);
-            } while (nSib.length === 0);
+            } while (nSib.length === 0 && parDir.length > 0);
 
             newElement = nSib;
           } else {


### PR DESCRIPTION
This is a simple fix that should prevent infinite loops in the navigation behavior described in Issue #117 by checking that the parent directory exists before attempting to use it to find navigation targets.

When the last item in a directory (at any level) is selected and the user navigates 'down', shinyFiles attempts to 'bubble up' until a sibling can be found and used as a navigation target. Previously, this was allowed to create an infinite loop when navigating 'down' from the last item in the root. Essentially, shinyFiles was trying to navigate up the directory hierarchy infinitely.