### PR TITLE
Add type-in box for directory name

### DIFF
--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -444,9 +444,34 @@ var shinyFiles = (function() {
                                         $('<a>', {href: '#', text: 'Sort direction'}).addClass($(button).data('sortDir')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-down')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-up')))
         						)
         					)
+        						
+        						//////begin new section
+        						///mabchoose
+        						).append(
+        					$('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+        						$('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                                    $('<span>').addClass('glyphicon glyphicon-pencil')
+                                )
+                            ).append(
+                                $('<ul>').addClass('dropdown-menu').append(
+                                    $('<li>').append(
+                                        $('<div>').addClass('input-group input-group-sm').append(
+                                            $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                                        ).append(
+                                            $('<span>').addClass('input-group-btn').append(
+                                                $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                                                    $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                            //end new section
         				).append(
 							$('<select>').addClass('sF-breadcrumps form-control input-sm')
 						)
+						
 					).append(
 						$('<div>').addClass('sF-fileWindow').append(
 							$('<div>').addClass('sF-fileList')
@@ -489,6 +514,7 @@ var shinyFiles = (function() {
         modal.find('.sF-navigate #sF-btn-forward').on('click', function() {
 			moveForward(button, modal);
 		})
+		
         
         // View changing
         modal.find('.sF-view').on('click', 'button', function() {
@@ -531,6 +557,41 @@ var shinyFiles = (function() {
 				toggleSelectButton(modal);
 				return false;
 			})
+			
+		// Text Choice
+		
+		///mabchoose
+        modal.find('.sF-textChoice').on('click', function() {
+            var directory = getCurrentDirectory(modal);
+            var disabled = $(this).find('button').prop('disabled')
+            if(!disabled) {
+                $(this).toggleClass('open')
+    			    .find('button.sF-btn-textChoice').toggleClass('active');
+                if($(this).hasClass('open')) {
+                    $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+                    $(this).find('.input-group-btn>button').prop('disabled', true);
+                }
+            }
+			return false;
+		})
+		modal.find('.sF-textChoice input').on('keyup', function(e) {
+            var disabled = $(this).val() == '';
+            $(this).parent().find('button').prop('disabled', disabled);
+            if(e.keyCode == 13) {
+                 setPathFromTextInput($(this).val(), modal);
+            } else if(e.keyCode == 27) {
+                var parent = $(this).closest('.sF-textChoice');
+                parent.toggleClass('open', false)
+                    .find('button.sF-btn-textChoice').toggleClass('active', true);
+            }
+        })
+		modal.find('.sF-textChoice ul').on('click', function() {
+            return false;
+        })
+        modal.find('.sF-textChoice ul button').on('click', function() {
+            var name = $(this).closest('.input-group').find('input').val();
+           setPathFromTextInput(name,modal);
+        })
         
         // Custom events
         modal
@@ -896,6 +957,29 @@ var shinyFiles = (function() {
                                         $('<a>', {href: '#', text: 'Sort direction'}).addClass($(button).data('sortDir')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-down')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-up')))
         						)
         					)
+        							//////begin new section
+        						///mabsave
+        						).append( 
+        					$('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+        						$('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                                    $('<span>').addClass('glyphicon glyphicon-pencil')
+                                )
+                            ).append(
+                                $('<ul>').addClass('dropdown-menu').append(
+                                    $('<li>').append(
+                                        $('<div>').addClass('input-group input-group-sm').append(
+                                            $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                                        ).append(
+                                            $('<span>').addClass('input-group-btn').append(
+                                                $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                                                    $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                            //end new section
         				).append(
 							$('<select>').addClass('sF-breadcrumps form-control input-sm')
 						)
@@ -1012,6 +1096,41 @@ var shinyFiles = (function() {
 				return false;
 			})
         
+        //Folder Text Selection
+        ///mabsave
+        modal.find('.sF-textChoice').on('click', function() {
+            var directory = getCurrentDirectory(modal);
+            var disabled = $(this).find('button').prop('disabled')
+            if(!disabled) {
+                $(this).toggleClass('open')
+    			    .find('button.sF-btn-textChoice').toggleClass('active');
+                if($(this).hasClass('open')) {
+                    $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+                    $(this).find('.input-group-btn>button').prop('disabled', true);
+                }
+            }
+			return false;
+		})
+		modal.find('.sF-textChoice input').on('keyup', function(e) {
+            var disabled = $(this).val() == '';
+            $(this).parent().find('button').prop('disabled', disabled);
+            if(e.keyCode == 13) {
+                 setPathFromTextInput($(this).val(), modal);
+            } else if(e.keyCode == 27) {
+                var parent = $(this).closest('.sF-textChoice');
+                parent.toggleClass('open', false)
+                    .find('button.sF-btn-textChoice').toggleClass('active', true);
+            }
+        })
+		modal.find('.sF-textChoice ul').on('click', function() {
+            return false;
+        })
+        modal.find('.sF-textChoice ul button').on('click', function() {
+            var name = $(this).closest('.input-group').find('input').val();
+           setPathFromTextInput(name,modal);
+        })
+        
+        
         // Folder creation
         modal.find('.sF-newDir').on('click', function() {
             var disabled = $(this).find('button').prop('disabled')
@@ -1040,7 +1159,7 @@ var shinyFiles = (function() {
             return false;
         })
         modal.find('.sF-newDir ul button').on('click', function() {
-            var name = $(this).closest('input-group').find('input').val();
+            var name = $(this).closest('.input-group').find('input').val();
             createFolder(name, modal);
         })
         
@@ -1284,6 +1403,29 @@ var shinyFiles = (function() {
                                         $('<a>', {href: '#', text: 'Sort direction'}).addClass($(button).data('sortDir')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-down')).prepend($('<span>').addClass('glyphicon glyphicon-arrow-up')))
         						)
         					)
+        							//////begin new section
+        						///mabfolder
+        						).append( 
+        					$('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+        						$('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                                    $('<span>').addClass('glyphicon glyphicon-pencil')
+                                )
+                            ).append(
+                                $('<ul>').addClass('dropdown-menu').append(
+                                    $('<li>').append(
+                                        $('<div>').addClass('input-group input-group-sm').append(
+                                            $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                                        ).append(
+                                            $('<span>').addClass('input-group-btn').append(
+                                                $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                                                    $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                            //end new section
         				).append(
 							$('<select>').addClass('sF-breadcrumps form-control input-sm')
 						)
@@ -1334,6 +1476,41 @@ var shinyFiles = (function() {
         modal.find('.sF-responseButtons #sF-selectButton').on('click', function() {
 			selectFiles(button, modal);
 		})
+		
+		//Folder Text Selection
+        ///mabsave
+        modal.find('.sF-textChoice').on('click', function() {
+            var directory = getCurrentDirectory(modal);
+            var disabled = $(this).find('button').prop('disabled')
+            if(!disabled) {
+                $(this).toggleClass('open')
+    			    .find('button.sF-btn-textChoice').toggleClass('active');
+                if($(this).hasClass('open')) {
+                    $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+                    $(this).find('.input-group-btn>button').prop('disabled', true);
+                }
+            }
+			return false;
+		})
+		modal.find('.sF-textChoice input').on('keyup', function(e) {
+            var disabled = $(this).val() == '';
+            $(this).parent().find('button').prop('disabled', disabled);
+            if(e.keyCode == 13) {
+                 setPathFromTextInput($(this).val(), modal);
+            } else if(e.keyCode == 27) {
+                var parent = $(this).closest('.sF-textChoice');
+                parent.toggleClass('open', false)
+                    .find('button.sF-btn-textChoice').toggleClass('active', true);
+            }
+        })
+		modal.find('.sF-textChoice ul').on('click', function() {
+            return false;
+        })
+        modal.find('.sF-textChoice ul button').on('click', function() {
+            var name = $(this).closest('.input-group').find('input').val();
+           setPathFromTextInput(name,modal);
+        })
+        
         
         // Create dir
         modal.find('.sF-newDir').on('click', function() {
@@ -1363,7 +1540,7 @@ var shinyFiles = (function() {
             return false;
         })
         modal.find('.sF-newDir ul button').on('click', function() {
-            var name = $(this).closest('input-group').find('input').val();
+            var name = $(this).closest('.input-group').find('input').val();
             createFolder(name, modal);
         })
         
@@ -1656,6 +1833,54 @@ var shinyFiles = (function() {
             $(modal).find('.sF-newDir').toggleClass('open', false)
                 .find('.sF-btn-newDir').toggleClass('active', false);
         }
+    };
+    
+    //mabxx
+    var setPathFromTextInput = function(path, modal) {
+        if(path != '') {
+            var button = $($(modal).data('button'));
+            var currentDir = getCurrentDirectory(modal);
+            var date = new Date();
+            var data = {
+                name: path,
+                path: currentDir.path,
+                root: currentDir.root,
+                id: date.getTime()
+            }
+            
+            var breadcrumps = modal.find('.sF-breadcrumps')
+            var volumes = breadcrumps.find('optgroup option')
+           
+            //Set a new root, if there is a match in the text path
+            var foundRoot = false;
+            $(volumes).each(function(i,volume) {
+                if(path.startsWith($(volume).val())){
+                    data.root = $(volume).val();
+                    data.path = path.substr(data.root.length).split(/[/\\]/)
+                    foundRoot = true;
+                }
+            })
+            if(!foundRoot){
+                debugger;
+                var searchPattern = new RegExp(/^[/\\]/);
+                if(searchPattern.test(path)){ //From the root
+                    data.path = path.split(/[/\\]/);
+                }else{ //relative path
+                    data.path.push(path.split(/[/\\]/));
+                }
+            }
+            
+            $(modal).find('.sF-textChoice').toggleClass('open', false)
+                .find('.sF-btn-textChoice').toggleClass('active', false);
+        
+        
+            modal.data('currentData').contentPath = data.path;
+            console.log($(button).attr('id'))
+            Shiny.onInputChange($(button).attr('id')+'-modal', data);
+            $(button).data('back').push(currentDir);
+		    $(button).data('forward', []);
+        }
+        return false;
     };
     
     var getPath = function(element) {

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1505,6 +1505,7 @@ var shinyFiles = (function() {
 		})
 		var setPathFromTextInputFolderSelection = function(path, modal) {
             if(path != '') {
+                console.log(modal.data('currentData').selectedRoot);
                 var currentDir = getCurrentDirectoryFolderSelection(modal);
                 var date = new Date();
                 var data = {
@@ -1524,7 +1525,8 @@ var shinyFiles = (function() {
                         foundRoot = true;
                         if(data.root != $(volume).val()){
                             data.root = $(volume).val();
-                            changeVolume(data.root,modal);
+                            //changeVolume(data.root,modal);
+                            modal.data('currentData').selectedRoot = data.root;
                         }
                         data.path = path.substr(data.root.length).split(/[/\\]/);
                     }
@@ -1546,7 +1548,7 @@ var shinyFiles = (function() {
 
                 //traverse the new path and expand directories
                 if(!parent.hasClass('empty')) {
-                    var tree = JSON.parse(JSON.stringify(modal.data('currentData').tree);
+                    var tree = modal.data('currentData').tree;
                     var tpath = JSON.parse(JSON.stringify(data.path))
                     tpath.shift()
                     while(true) {
@@ -1560,10 +1562,6 @@ var shinyFiles = (function() {
                             tree = tree.children.filter(function(f) {
                                 return f.name == name;
                             })[0];
-                            newParent = $(parent).find("sF-content .sF-directory :contains(" + name + ")").closest(".sF-directory");
-                            if(newParent !== undefined){
-                                parent = newParent;
-                            }
                         }
                     }
                     
@@ -1571,15 +1569,15 @@ var shinyFiles = (function() {
                 
                 //select the final path element
                 parent.toggleClass('selected');
-                debugger;
-                        
+
                 $(modal).find('.sF-textChoice').toggleClass('open', false)
                     .find('.sF-btn-textChoice').toggleClass('active', false);
 
                 modal.data('currentData').contentPath = data.path;
                     
-                console.log(modal.data('currentData'))
                 Shiny.onInputChange($(button).attr('id')+'-modal', modal.data('currentData'));
+               // newParent = $(parent).find(".sF-content .sF-directory :contains(" + name + ")").closest(".sF-directory");
+                            
             }
             return false;
         };  

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -32,7 +32,7 @@
 }
 
 .sF-breadcrumps {
-	width: calc(100% - 255px);
+	width: calc(100% - 290px);
 	margin-left: auto
 }
 
@@ -413,6 +413,33 @@
 }
 
 /*
+    text Choice
+*/
+.sF-textChoice .dropdown-menu {
+	padding: 5px;
+}
+.sF-textChoice .dropdown-menu::before {
+  position: absolute;
+  top: -7px;
+  left: 9px;
+  display: inline-block;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-left: 7px solid transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.2);
+  content: '';
+}
+.sF-textChoice .dropdown-menu::after {
+  position: absolute;
+  top: -6px;
+  left: 10px;
+  display: inline-block;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid #ffffff;
+  border-left: 6px solid transparent;
+  content: '';
+}
+/*
     File saver specifics
 */
 .sF-filenaming {
@@ -422,6 +449,12 @@
     margin-right: 15px;
     border-radius: 4px;
 }
+
+.sF-filenaming .sF-textChoice>#sF-btn-textChoice {
+    margin-right: 15px;
+    border-radius: 4px;
+}
+
 .input-group.sF-filenaming input.sF-filename.form-control {
     border-bottom-left-radius: 4px;
     border-top-left-radius: 4px;


### PR DESCRIPTION
This pull-request completes #53 
I have added a new pencil button next to the directory dropdown that works similarly to the create directory button. 

Volumes are specified without any preceding slashes. For example: "R Installation/doc/html"

This is implemented for File Select, Folder Select, and Save File