### PR TITLE
Type in for file path

### DIFF
--- a/R/filesave.R
+++ b/R/filesave.R
@@ -52,6 +52,9 @@ shinyFileSave <- function(input, id, updateFreq=0, session=getSession(),
     if (isTRUE(newDir$exist)) {
       currentDir <<- newDir
       session$sendCustomMessage(message, list(id = clientId, dir = newDir))
+    }else{
+      currentDir$exist = FALSE
+      session$sendCustomMessage(message, list(id = clientId, dir = currentDir))
     }
     if (updateFreq > 0) invalidateLater(updateFreq, session)
   }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -573,6 +573,7 @@ var shinyFiles = (function() {
       files: parsedFiles,
       location: data.breadcrumps,
       writable: data.writable,
+      exist: data.exist,
       rootNames: data.roots,
       selectedRoot: data.root
     };
@@ -746,25 +747,45 @@ var shinyFiles = (function() {
     removeFileChooser(button, modal, data);
   };
     
-    var setPermission = function(modal, writable) {
-      var currentState = $(modal).find('.sF-permission').length == 0;
-      var footer = $(modal).find('.modal-footer');
-      var overwrite = $($(modal).data('button')).hasClass('shinySave') ? true : filesSelected(modal);
-      
-      $(modal).find('#sF-btn-newDir').prop('disabled', !(overwrite && writable));
-      
-      if(writable || !overwrite) {
-        footer.find('.sF-permission').remove();
-      } else if(currentState != writable) {
-        footer.prepend(
-          $('<div>').addClass('sF-permission text-warning').append(
-            $('<span>').addClass('glyphicon glyphicon-warning-sign')
-          ).append(
-            $('<span>').text('No write permission for folder')
-          )
+  var setPermission = function(modal, writable) {
+    var currentState = $(modal).find('.sF-warning').length == 0;
+    var footer = $(modal).find('.modal-footer');
+    var overwrite = $($(modal).data('button')).hasClass('shinySave') ? true : filesSelected(modal);
+    
+    $(modal).find('#sF-btn-newDir').prop('disabled', !(overwrite && writable));
+    
+    if(writable || !overwrite) {
+      footer.find('.sF-warning').remove();
+    } else if(currentState != writable) {
+      footer.prepend(
+        $('<div>').addClass('sF-warning text-warning').append(
+          $('<span>').addClass('glyphicon glyphicon-warning-sign')
+        ).append(
+          $('<span>').text('No write permission for folder')
         )
-      }
+      )
     }
+  }
+  
+  var setExists = function(modal, exists) {
+    var currentState = $(modal).find('.sF-warning').length == 0;
+    var footer = $(modal).find('.modal-footer');
+    
+    $(modal).find('#sF-btn-newDir').prop('disabled', !(exists));
+    
+    
+    footer.find('.sF-warning').remove();
+    if(!exists) {
+      footer.prepend(
+        $('<div>').addClass('sF-warning text-warning').append(
+          $('<span>').addClass('glyphicon glyphicon-warning-sign')
+        ).append(
+          $('<span>').text('Folder does not exist')
+        )
+      )
+    }
+  }
+  
   // General functionality ends
     
     
@@ -964,6 +985,7 @@ var shinyFiles = (function() {
           var disabled = $(this).val() == '';
           $(this).parent().find('button').prop('disabled', disabled);
           if(e.keyCode == 13) {
+             e.stopPropagation();
              setPathFromTextInput($(this).val(), modal);
           } else if(e.keyCode == 27) {
             var parent = $(this).closest('.sF-textChoice');
@@ -1168,6 +1190,7 @@ var shinyFiles = (function() {
     if($(element).hasClass('shinySave')) {
       setPermission(modal, data.writable);
     }
+    setExists(modal, data.exist);
     toggleSelectButton(modal);
     
     modal.data('currentData', data);
@@ -1567,7 +1590,8 @@ var shinyFiles = (function() {
           var disabled = $(this).val() == '';
           $(this).parent().find('button').prop('disabled', disabled);
           if(e.keyCode == 13) {
-             setPathFromTextInput($(this).val(), modal);
+            e.stopPropagation();
+            setPathFromTextInput($(this).val(), modal);
           } else if(e.keyCode == 27) {
             var parent = $(this).closest('.sF-textChoice');
             parent.toggleClass('open', false)
@@ -1731,7 +1755,7 @@ var shinyFiles = (function() {
   var evalFilename = function(modal) {
     var parent = modal.find('.sF-filenaming');
     var name = getFilename(modal).name;
-    modal.find('#sF-selectButton').prop('disabled', name == '' || modal.find('.sF-permission').length != 0);
+    modal.find('#sF-selectButton').prop('disabled', name == '' || modal.find('.sF-warning').length != 0);
     if(nameExist(modal, name)) {
       parent.toggleClass('has-feedback', true)
         .toggleClass('has-warning', true);
@@ -2049,7 +2073,8 @@ var shinyFiles = (function() {
         var disabled = $(this).val() == '';
         $(this).parent().find('button').prop('disabled', disabled);
         if(e.keyCode == 13) {
-           setPathFromTextInputFolderSelection($(this).val(), modal);
+          e.stopPropagation();
+          setPathFromTextInputFolderSelection($(this).val(), modal);
         } else if(e.keyCode == 27) {
           var parent = $(this).closest('.sF-textChoice');
           parent.toggleClass('open', false)
@@ -2237,6 +2262,7 @@ var shinyFiles = (function() {
     
     toggleSelectButton(modal);
     setPermission(modal, data.writable);
+    setExists(modal,data.exist);
     
     modal.data('currentData', data);
     $(modal).trigger('change');

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -850,6 +850,26 @@ var shinyFiles = (function() {
                 )
               )
             ).append(
+              $('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                  $('<span>').addClass('glyphicon glyphicon-pencil')
+                )
+              ).append(
+                $('<ul>').addClass('dropdown-menu').append(
+                  $('<li>').append(
+                    $('<div>').addClass('input-group input-group-sm').append(
+                      $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                    ).append(
+                      $('<span>').addClass('input-group-btn').append(
+                        $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                          $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            ).append(
               $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
                 $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
                   $('<span>').addClass('glyphicon glyphicon-refresh')
@@ -925,6 +945,39 @@ var shinyFiles = (function() {
         
         $(modal).trigger('fileSort', [$(this).parent().find('.selected a').text(), $(this).find('a').attr('class')])
       })
+
+		// Text Choice
+        modal.find('.sF-textChoice').on('click', function() {
+          var directory = getCurrentDirectory(modal);
+          var disabled = $(this).find('button').prop('disabled')
+          if(!disabled) {
+            $(this).toggleClass('open')
+              .find('button.sF-btn-textChoice').toggleClass('active');
+            if($(this).hasClass('open')) {
+              $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+              $(this).find('.input-group-btn>button').prop('disabled', true);
+            }
+          }
+          return false;
+		})
+		modal.find('.sF-textChoice input').on('keyup', function(e) {
+          var disabled = $(this).val() == '';
+          $(this).parent().find('button').prop('disabled', disabled);
+          if(e.keyCode == 13) {
+             setPathFromTextInput($(this).val(), modal);
+          } else if(e.keyCode == 27) {
+            var parent = $(this).closest('.sF-textChoice');
+            parent.toggleClass('open', false)
+              .find('button.sF-btn-textChoice').toggleClass('active', true);
+          }
+        })
+		modal.find('.sF-textChoice ul').on('click', function() {
+          return false;
+        })
+        modal.find('.sF-textChoice ul button').on('click', function() {
+          var name = $(this).closest('.input-group').find('input').val();
+          setPathFromTextInput(name,modal);
+        })
         
     // Breadcrump and volume navigation
     modal.find('.sF-breadcrumps').on('change', function() {
@@ -1348,6 +1401,26 @@ var shinyFiles = (function() {
                   )
                 )
               )
+            ).append( 
+              $('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                  $('<span>').addClass('glyphicon glyphicon-pencil')
+                )
+              ).append(
+                $('<ul>').addClass('dropdown-menu').append(
+                  $('<li>').append(
+                    $('<div>').addClass('input-group input-group-sm').append(
+                      $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                    ).append(
+                      $('<span>').addClass('input-group-btn').append(
+                        $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                          $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                        )
+                      )
+                    )
+                  )
+                )
+              )
             ).append(
               $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
                 $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
@@ -1475,6 +1548,40 @@ var shinyFiles = (function() {
         }
         return false;
       })
+
+        //Folder Text Selection
+        modal.find('.sF-textChoice').on('click', function() {
+          var directory = getCurrentDirectory(modal);
+          var disabled = $(this).find('button').prop('disabled')
+          if(!disabled) {
+            $(this).toggleClass('open')
+              .find('button.sF-btn-textChoice').toggleClass('active');
+            if($(this).hasClass('open')) {
+              $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+              $(this).find('.input-group-btn>button').prop('disabled', true);
+            }
+          }
+          return false;
+		})
+		modal.find('.sF-textChoice input').on('keyup', function(e) {
+          var disabled = $(this).val() == '';
+          $(this).parent().find('button').prop('disabled', disabled);
+          if(e.keyCode == 13) {
+             setPathFromTextInput($(this).val(), modal);
+          } else if(e.keyCode == 27) {
+            var parent = $(this).closest('.sF-textChoice');
+            parent.toggleClass('open', false)
+              .find('button.sF-btn-textChoice').toggleClass('active', true);
+          }
+        })
+		modal.find('.sF-textChoice ul').on('click', function() {
+          return false;
+        })
+        modal.find('.sF-textChoice ul button').on('click', function() {
+          var name = $(this).closest('.input-group').find('input').val();
+          setPathFromTextInput(name,modal);
+        })
+        
         
     // Folder creation
     modal.find('.sF-newDir').on('click', function() {
@@ -1759,6 +1866,26 @@ var shinyFiles = (function() {
                   )
                 )
               )
+            ).append( 
+              $('<div>').addClass('sF-textChoice btn-group input-group-btn btn-group-sm').append(
+                $('<button>', {id: 'sF-btn-textChoice', text: ''}).addClass('btn btn-default dropdown-toggle').prepend(
+                  $('<span>').addClass('glyphicon glyphicon-pencil')
+                )
+              ).append(
+                $('<ul>').addClass('dropdown-menu').append(
+                  $('<li>').append(
+                    $('<div>').addClass('input-group input-group-sm').append(
+                      $('<input>', {type: 'text', placeholder: 'Enter Path'}).addClass('form-control')
+                    ).append(
+                      $('<span>').addClass('input-group-btn').append(
+                        $('<button>', {type: 'button'}).addClass('btn btn-default').prop('disabled', true).append(
+                          $('<span>').addClass('glyphicon glyphicon-ok-sign')    
+                        )
+                      )
+                    )
+                  )
+                )
+              )
             ).append(
               $('<div>').addClass('sF-refresh btn-group btn-group-sm').append(
                 $('<button>', {id: 'sF-btn-refresh'}).addClass('btn btn-default').append(
@@ -1815,6 +1942,127 @@ var shinyFiles = (function() {
     modal.find('.sF-responseButtons #sF-selectButton').on('click', function() {
       selectFiles(button, modal);
     })
+
+      //Folder Text Selection
+      var getCurrentDirectoryFolderSelection = function(modal){
+        var path = getPath($(modal).find('.sF-dirList .selected'));
+        $(button).data('directory', path)
+          .trigger('selection', path);
+        var data = {
+          path: path,
+          root: $(modal).data('currentData').selectedRoot
+        };
+        return data;
+      }
+		
+      modal.find('.sF-textChoice').on('click', function() {
+        var directory = getCurrentDirectoryFolderSelection(modal);
+        var disabled = $(this).find('button').prop('disabled')
+        if(!disabled) {
+          $(this).toggleClass('open')
+            .find('button.sF-btn-textChoice').toggleClass('active');
+          if($(this).hasClass('open')) {
+            $(this).find('input').val(directory.root + directory.path.join("/")).focus();
+            $(this).find('.input-group-btn>button').prop('disabled', true);
+          }
+        }
+        return false;
+      })
+      var setPathFromTextInputFolderSelection = function(path, modal) {
+        if(path != '') {
+          var currentDir = getCurrentDirectoryFolderSelection(modal);
+          var date = new Date();
+          var data = {
+              name: path,
+              path: currentDir.path,
+              root: currentDir.root,
+              id: date.getTime()
+          }
+          
+          var breadcrumps = modal.find('.sF-breadcrumps')
+          var volumes = breadcrumps.find('optgroup option')
+         
+          //Set a new root, if there is a match in the text path
+          var foundRoot = false;
+          $(volumes).each(function(i,volume) {
+            if(path.startsWith($(volume).val())){
+              foundRoot = true;
+              if(data.root != $(volume).val()){
+                data.root = $(volume).val();
+                modal.data('currentData').selectedRoot = data.root;
+              }
+              data.path = path.substr(data.root.length).split(/[/\\]/);
+            }
+          })
+
+          
+          if(!foundRoot){
+            var searchPattern = new RegExp(/^[/\\]/);
+            if(searchPattern.test(path)){ //From the root
+              data.path = path.split(/[/\\]/);
+            }else{ //relative path
+              data.path.push(path.split(/[/\\]/));
+            }
+          }
+          
+          //deselect selected elements
+          $('.sF-dirList .selected').toggleClass('selected');
+          parent = $(".sF-dirList .sF-directory :contains(" + data.root + ")").closest(".sF-directory");
+
+          //traverse the new path and expand directories
+          if(!parent.hasClass('empty')) {
+            modal.data('currentData').tree = new Object();
+            tree = modal.data('currentData').tree;
+            tree.name = "";
+            tree.expanded = false;
+            tree.empty = true;
+            tree.children = new Array(0);
+            var tpath = JSON.parse(JSON.stringify(data.path))
+            tpath.shift();
+            for(name of tpath){
+              tree.expanded = true;
+              tree.empty = false;
+              tree.children = new Array(new Object);
+              tree = tree.children[0];
+              tree.name = name
+              tree.expanded = false;
+              tree.empty = true;
+              tree.children = new Array(0);
+            }
+          }
+          
+          //select the final path element
+          parent.toggleClass('selected');
+
+          $(modal).find('.sF-textChoice').toggleClass('open', false)
+            .find('.sF-btn-textChoice').toggleClass('active', false);
+
+          modal.data('currentData').contentPath = data.path;
+              
+          Shiny.onInputChange($(button).attr('id')+'-modal', modal.data('currentData'));
+                      
+        }
+        return false;
+      };  
+        
+      modal.find('.sF-textChoice input').on('keyup', function(e) {
+        var disabled = $(this).val() == '';
+        $(this).parent().find('button').prop('disabled', disabled);
+        if(e.keyCode == 13) {
+           setPathFromTextInputFolderSelection($(this).val(), modal);
+        } else if(e.keyCode == 27) {
+          var parent = $(this).closest('.sF-textChoice');
+          parent.toggleClass('open', false)
+            .find('button.sF-btn-textChoice').toggleClass('active', true);
+        }
+      })
+      modal.find('.sF-textChoice ul').on('click', function() {
+        return false;
+      })
+      modal.find('.sF-textChoice ul button').on('click', function() {
+        var name = $(this).closest('.input-group').find('input').val();
+        setPathFromTextInputFolderSelection(name,modal);
+      })
           
     // Create dir
     modal.find('.sF-newDir').on('click', function() {
@@ -2180,6 +2428,51 @@ var shinyFiles = (function() {
       $(modal).find('.sF-newDir').toggleClass('open', false)
         .find('.sF-btn-newDir').toggleClass('active', false);
     }
+  };
+
+  var setPathFromTextInput = function(path, modal) {
+    if(path != '') {
+      var button = $($(modal).data('button'));
+      var currentDir = getCurrentDirectory(modal);
+      var date = new Date();
+      var data = {
+          name: path,
+          path: currentDir.path,
+          root: currentDir.root,
+          id: date.getTime()
+      }
+      
+      var breadcrumps = modal.find('.sF-breadcrumps')
+      var volumes = breadcrumps.find('optgroup option')
+     
+      //Set a new root, if there is a match in the text path
+      var foundRoot = false;
+      $(volumes).each(function(i,volume) {
+        if(path.startsWith($(volume).val())){
+          data.root = $(volume).val();
+          data.path = path.substr(data.root.length).split(/[/\\]/)
+          foundRoot = true;
+        }
+      })
+      if(!foundRoot){
+        var searchPattern = new RegExp(/^[/\\]/);
+        if(searchPattern.test(path)){ //From the root
+            data.path = path.split(/[/\\]/);
+        }else{ //relative path
+            data.path.push(path.split(/[/\\]/));
+        }
+      }
+      
+      $(modal).find('.sF-textChoice').toggleClass('open', false)
+        .find('.sF-btn-textChoice').toggleClass('active', false);
+  
+  
+      modal.data('currentData').contentPath = data.path;
+      Shiny.onInputChange($(button).attr('id')+'-modal', data);
+      $(button).data('back').push(currentDir);
+      $(button).data('forward', []);
+    }
+    return false;
   };
     
   var getPath = function(element) {

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -37,7 +37,7 @@
 }
 
 .sF-breadcrumps {
-  width: calc(100% - 320px);
+  width: calc(100% - 330px);
   margin-left: auto;
   min-width: 150px;
 }
@@ -70,7 +70,7 @@
 }
 
 .btn-toolbar .sF-breadcrumps {
-  margin-left: 5px;
+  margin-left: 30px;
   float: left;
 }
 

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -18,12 +18,12 @@
   border-radius: 5px;
   overflow: auto;
 }
-.sF-permission {
+.sF-warning {
   float: left;
   vertical-align: middle;
   padding: 7px 0;
 }
-.sF-permission span {
+.sF-warning span {
   padding-right: 5px;
 }
 .sF-fileList div {

--- a/inst/www/styles.css
+++ b/inst/www/styles.css
@@ -37,7 +37,7 @@
 }
 
 .sF-breadcrumps {
-  width: calc(100% - 300px);
+  width: calc(100% - 320px);
   margin-left: auto;
   min-width: 150px;
 }
@@ -431,6 +431,33 @@
 }
 
 /*
+    text Choice
+*/
+.sF-textChoice .dropdown-menu {
+	padding: 5px;
+}
+.sF-textChoice .dropdown-menu::before {
+  position: absolute;
+  top: -7px;
+  left: 9px;
+  display: inline-block;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-left: 7px solid transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.2);
+  content: '';
+}
+.sF-textChoice .dropdown-menu::after {
+  position: absolute;
+  top: -6px;
+  left: 10px;
+  display: inline-block;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid #ffffff;
+  border-left: 6px solid transparent;
+  content: '';
+}
+/*
   File saver specifics
 */
 .sF-filenaming {
@@ -439,6 +466,11 @@
 .sF-filenaming .sF-newDir>#sF-btn-newDir {
   margin-right: 15px;
   border-radius: 4px;
+}
+
+.sF-filenaming .sF-textChoice>#sF-btn-textChoice {
+    margin-right: 15px;
+    border-radius: 4px;
 }
 .input-group.sF-filenaming input.sF-filename.form-control {
   border-bottom-left-radius: 4px;


### PR DESCRIPTION
This pull-request completes #53
I have added a new pencil button next to the directory dropdown that works similarly to the create directory button.

Volumes are specified without any preceding slashes. For example: "R Installation/doc/html"

This is implemented for File Select, Folder Select, and Save File