### PR TITLE
Extend functionality of type in box to include files

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -56,6 +56,18 @@ fileGetter <- function(roots, restrictions, filetypes, pattern, hidden = FALSE) 
     if (is.null(root)) root <- names(currentRoots)[1]
     
     fulldir <- path(currentRoots[root], paste0(dir, collapse = "/"))
+    selectedFile = ""
+    if(file.exists(fulldir) && !dir.exists(fulldir)){
+      #dir is a normal file, not a directory
+      #get the filename, and use it as the selectedFile
+      selectedFile = sub(".*/(.*)$","\\1",fulldir)
+      #shorten the directory
+      fulldir = sub("(.*)/.*$","\\1",fulldir)
+      #dir also needs shortened for breadcrumps
+      dir = sub("(.*)/.*$","\\1",dir)
+    }
+    
+    
     writable <- as.logical(file_access(fulldir, "write"))
     files <- suppressWarnings(dir_ls(fulldir, all = hidden, fail = FALSE))
   
@@ -100,7 +112,8 @@ fileGetter <- function(roots, restrictions, filetypes, pattern, hidden = FALSE) 
       exist = as.logical(file_exists(fulldir)),
       breadcrumps = I(c("", breadcrumps[breadcrumps != ""])),
       roots = I(names(currentRoots)),
-      root = root
+      root = root,
+      selectedFile = selectedFile
     )
   }
 }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -575,7 +575,8 @@ var shinyFiles = (function() {
       writable: data.writable,
       exist: data.exist,
       rootNames: data.roots,
-      selectedRoot: data.root
+      selectedRoot: data.root,
+      selectedFile: data.selectedFile
     };
   };
     
@@ -1065,6 +1066,7 @@ var shinyFiles = (function() {
   };
 
   var populateFileChooser = function(element, data, forceUpdate) {
+
     var modal = $(element).data('modal');
       
     $(element).data('dataCache', data);
@@ -1133,7 +1135,7 @@ var shinyFiles = (function() {
         var d = data.files[i];
         
         modal.find('.sF-fileList').append(
-          $('<div>').toggleClass('sF-file', !d.isDir).toggleClass('sF-directory', d.isDir).append(
+          $('<div>').toggleClass('sF-file', !d.isDir).toggleClass('selected',d.name==data.selectedFile).toggleClass('sF-directory', d.isDir).append(
             $('<div>').addClass('sF-file-icon').addClass('sF-filetype-'+d.extension)
           ).append(
             $('<div>').addClass('sF-file-name').append(
@@ -1162,12 +1164,13 @@ var shinyFiles = (function() {
         }).remove();
       };
       
+      
       if (Object.keys(newFiles).length === 0) {
         for (i in newFiles) {
           var d = newFiles[i];
           
           modal.find('.sF-fileList').append(
-            $('<div>').toggleClass('sF-file', !d.isDir).toggleClass('sF-directory', d.isDir).append(
+            $('<div>').toggleClass('sF-file', !d.isDir).toggleClass('selected',d.name==data.selectedFile).toggleClass('sF-directory', d.isDir).append(
               $('<div>').addClass('sF-file-icon').addClass('sF-filetype-'+d.extension)
             ).append(
               $('<div>').addClass('sF-file-name').append(
@@ -1189,6 +1192,9 @@ var shinyFiles = (function() {
     
     if($(element).hasClass('shinySave')) {
       setPermission(modal, data.writable);
+      if(data.selectedFile != ""){
+        setFilename(modal,data.selectedFile)
+      }
     }
     setExists(modal, data.exist);
     toggleSelectButton(modal);


### PR DESCRIPTION
Allow the user to type a path, including the filename. In filechoose, the file will be selected if it exists. In filesave, if the file does not exist, but the base directory does, the filename will be entered into the dialog.