### PR TITLE
Trigger selection event

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -348,8 +348,8 @@ shinyFileChoose <- function(input, id, updateFreq = 0, session = getSession(),
 #'
 #' If the shiny app uses custom Javascript it is possible to react to selections
 #' directly from the javascript. Once a selection has been made, the button will
-#' fire of the event 'selection' and pass the selection data along with the
-#' event. To listen for this event you simple add:
+#' fire the event 'selection' and pass the selection data along with the event.
+#' To listen for this event you simple add:
 #'
 #' \preformatted{
 #' $(button).on('selection', function(event, path) {
@@ -357,7 +357,17 @@ shinyFileChoose <- function(input, id, updateFreq = 0, session = getSession(),
 #' })
 #' }
 #'
-#' in the same way a 'cancel' event is fired when a user dismisses a selection
+#' In the same way, when a file is saved, the save button will fire the event
+#' 'save' and pass the file path along with the event. To listen for this event
+#' you can use:
+#' 
+#' \preformatted{
+#' $(button).on('save', function(event, path) {
+#'   // Do something with the path here
+#' })
+#' }
+#' 
+#' Moreover, a 'cancel' event is fired when a user dismisses a ShinyFiles dialog
 #' box. In that case, no path is passed on.
 #'
 #' Outside events the current selection is available as an object bound to the

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1817,7 +1817,8 @@ var shinyFiles = (function () {
     var file = getFilename(modal);
     $.extend(file, dir);
 
-    $(button).data('file', file);
+    $(button).data('file', file)
+      .trigger('selection', [file]);
 
     removeFileChooser(button, modal, file);
   }

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -1818,7 +1818,7 @@ var shinyFiles = (function () {
     $.extend(file, dir);
 
     $(button).data('file', file)
-      .trigger('selection', [file]);
+      .trigger('save', file);
 
     removeFileChooser(button, modal, file);
   }

--- a/man/shinyFiles-buttons.Rd
+++ b/man/shinyFiles-buttons.Rd
@@ -206,8 +206,8 @@ If no large version is specified the small version gets upscaled.
 
 If the shiny app uses custom Javascript it is possible to react to selections
 directly from the javascript. Once a selection has been made, the button will
-fire of the event 'selection' and pass the selection data along with the
-event. To listen for this event you simple add:
+fire the event 'selection' and pass the selection data along with the event.
+To listen for this event you simple add:
 
 \preformatted{
 $(button).on('selection', function(event, path) {
@@ -215,7 +215,17 @@ $(button).on('selection', function(event, path) {
 })
 }
 
-in the same way a 'cancel' event is fired when a user dismisses a selection
+In the same way, when a file is saved, the save button will fire the event
+'save' and pass the file path along with the event. To listen for this event
+you can use:
+
+\preformatted{
+$(button).on('save', function(event, path) {
+  // Do something with the path here
+})
+}
+
+Moreover, a 'cancel' event is fired when a user dismisses a ShinyFiles dialog
 box. In that case, no path is passed on.
 
 Outside events the current selection is available as an object bound to the


### PR DESCRIPTION
Fix for #162

To test it use the following code:

```
library(shiny)
library(shinyFiles)
library(shinyjs)
library(fs)

ui <- fluidPage(
  useShinyjs(),
  headerPanel("Basic example"),
  sidebarLayout(
    sidebarPanel(
      shinyFilesButton(id = "file",
                       label = "File select",
                       title = "Please select a file",
                       multiple = FALSE,
                       viewtype = "detail"),
      tags$hr(),
      shinySaveButton(id = "save",
                      label = "Save file",
                      title = "Save file as...",
                      filetype = list(text = "txt"),
                      viewtype = "icon"),
    ),
    mainPanel(
      h4(id = "text"),
    )
  )
)

server <- function(input, output, session) {
  volumes <- c(Home = fs::path_home())

  shinyFileChoose(input,
                  id = "file",
                  roots = volumes,
                  session = session)
  shinyFileSave(input,
                "save",
                roots = volumes,
                session = session)

  shinyjs::runjs(
    "$('#file').on('selection', function(event, path)
                                  {$('#text').text('Files button clicked');})"
  )
  shinyjs::runjs(
    "$('#save').on('selection', function(event, path)
                                  {$('#text').text('File save: ' + path.name);})"
  )
}

shinyApp(ui = ui, server = server)
```
